### PR TITLE
Improve GCS authentication setup

### DIFF
--- a/src/astro/sql/operators/agnostic_load_file.py
+++ b/src/astro/sql/operators/agnostic_load_file.py
@@ -140,10 +140,13 @@ class AgnosticLoadFile(BaseOperator):
         """
         get GCS credentials for storage.
         """
-        service_account_path = os.environ[
+        service_account_path = os.getenv(
             "AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS"
-        ]
-        client = Client.from_service_account_json(service_account_path)
+        )
+        if service_account_path:
+            client = Client.from_service_account_json(service_account_path)
+        else:
+            client = Client()
         return dict(client=client)
 
 

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -156,10 +156,13 @@ class SaveFile(BaseOperator):
         """
         get GCS credentials for storage
         """
-        service_account_path = os.environ[
+        service_account_path = os.getenv(
             "AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS"
-        ]
-        client = Client.from_service_account_json(service_account_path)
+        )
+        if service_account_path:
+            client = Client.from_service_account_json(service_account_path)
+        else:
+            client = Client()
         return dict(client=client)
 
     @staticmethod

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -69,6 +69,7 @@ class TestAgnosticLoadFile(unittest.TestCase):
     gcs_creds_filename = "gcp_credentials.json"
     bucket_name = "dag-authoring"
     blob_file_name = "homes.csv"
+    storage_client = None
 
     @classmethod
     def setUpClass(cls):
@@ -94,37 +95,9 @@ class TestAgnosticLoadFile(unittest.TestCase):
         self.dag = DAG(
             "test_dag", default_args={"owner": "airflow", "start_date": DEFAULT_DATE}
         )
+        self.init_storage_client()
 
-    def upload_blob(self):
-        self.delete_blob()
-
-        with open(str(self.cwd) + "/../data/" + str(self.blob_file_name)) as f:
-            content = f.read()
-
-        storage_client = storage.Client.from_service_account_json(
-            os.environ["AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS"]
-        )
-        bucket = storage_client.bucket(self.bucket_name)
-        blob = bucket.blob(self.blob_file_name)
-        t = blob.upload_from_filename(
-            str(self.cwd) + "/../data/" + str(self.blob_file_name)
-        )
-        print("File uploaded.")
-
-    def delete_blob(self):
-        storage_client = storage.Client.from_service_account_json(
-            os.environ["AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS"]
-        )
-
-        bucket = storage_client.bucket(self.bucket_name)
-        blob = bucket.blob(self.blob_file_name)
-        try:
-            blob.delete()
-            print("Blob {} deleted.".format(self.blob_file_name))
-        except NotFound as e:
-            print("File {} not found.".format(self.blob_file_name))
-
-    def create_gcs_creds(self):
+    def setup_gcs_credentials_for_astro(self):
         path = str(self.cwd) + "/" + self.gcs_creds_filename
         if os.path.isfile(path):
             self.delete_gcs_creds()
@@ -133,6 +106,37 @@ class TestAgnosticLoadFile(unittest.TestCase):
         with open(path, "w") as f:
             f.write(content)
         os.environ["AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS"] = path
+        return path
+
+    def init_storage_client(self):
+        service_account_credentials = os.getenv("GCP_CREDENTIALS")
+        if service_account_credentials:
+            path = self.setup_gcs_credentials_for_astro()
+            self.storage_client = storage.Client.from_service_account_json(path)
+        else:
+            self.storage_client = storage.Client()
+
+    def upload_blob(self):
+        self.delete_blob()
+
+        with open(str(self.cwd) + "/../data/" + str(self.blob_file_name)) as f:
+            content = f.read()
+
+        bucket = self.storage_client.bucket(self.bucket_name)
+        blob = bucket.blob(self.blob_file_name)
+        t = blob.upload_from_filename(
+            str(self.cwd) + "/../data/" + str(self.blob_file_name)
+        )
+        print("File uploaded.")
+
+    def delete_blob(self):
+        bucket = self.storage_client.bucket(self.bucket_name)
+        blob = bucket.blob(self.blob_file_name)
+        try:
+            blob.delete()
+            print("Blob {} deleted.".format(self.blob_file_name))
+        except NotFound as e:
+            print("File {} not found.".format(self.blob_file_name))
 
     def delete_gcs_creds(self):
         os.remove(str(self.cwd) + "/" + self.gcs_creds_filename)
@@ -431,7 +435,6 @@ class TestAgnosticLoadFile(unittest.TestCase):
 
     def test_aql_gcs_file_to_postgres(self):
         # To Do: add service account creds
-        self.create_gcs_creds()
         self.upload_blob()
         OUTPUT_TABLE_NAME = "expected_table_from_gcs_csv"
 


### PR DESCRIPTION
Improve GCS authentication setup.

Before, to use **astro** with GCS, we forced users to:
1. Have a GCP service account with the `Basic GCS role`
2. Declare `AIRFLOW__ASTRO__GOOGLE_APPLICATION_CREDENTIALS`

Although these can be seen as good practices, users might prefer to declare their GCP credentials using other standard ways supported by the `google-cloud-storage` package, including, but not exclusively, the ones documented in:
https://cloud.google.com/storage/docs/reference/libraries#setting_up_authentication

The current version allows GCP users to use **astro** from their local dev environments without setting up service accounts, by running:
```
gcloud auth application-default login
```

