### PR TITLE
Add support to load_file from json/ndjson

### DIFF
--- a/src/astro/sql/operators/agnostic_load_file.py
+++ b/src/astro/sql/operators/agnostic_load_file.py
@@ -114,8 +114,17 @@ class AgnosticLoadFile(BaseOperator):
             "gs": self._gcs_creds,
             "": lambda: None,
         }[urlparse(path).scheme]()
+        deserialiser = {
+            "parquet": pd.read_parquet,
+            "csv": pd.read_csv,
+            "json": pd.read_json,
+            "ndjson": pd.read_json,
+        }
+        deserialiser_params = {"ndjson": {"lines": True}}
         with open(path, transport_params=transport_params) as stream:
-            return {"parquet": pd.read_parquet, "csv": pd.read_csv}[file_type](stream)
+            return deserialiser[file_type](
+                stream, **deserialiser_params.get(file_type, {})
+            )
 
     def _s3fs_creds(self):
         # To-do: reuse this method from sql decorator

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -126,11 +126,21 @@ class SaveFile(BaseOperator):
             "gs": self._gcs_creds,
             "": lambda: None,
         }[urlparse(output_file_path).scheme]()
+
+        serialiser = {
+            "parquet": df.to_parquet,
+            "csv": df.to_csv,
+            # "json": pd.to_json,
+            # "ndjson": pd.to_json,
+        }
+        serialiser_params = {
+            # "ndjson": {"lines": True}
+        }
         with open(
             output_file_path, mode="wb", transport_params=transport_params
         ) as stream:
-            {"csv": df.to_csv, "parquet": df.to_parquet}[self.output_file_format](
-                stream
+            serialiser[self.output_file_format](
+                stream, **serialiser_params.get(self.output_file_format, {})
             )
 
     def _s3fs_creds(self):

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,4 @@
+id,name
+1,First
+2,Second
+3,Third with unicode पांचाल

--- a/tests/data/sample.json
+++ b/tests/data/sample.json
@@ -1,0 +1,1 @@
+{"id": {"0": "1", "1": "2", "2": "3"}, "name": {"0": "First", "1":  "Second", "2": "Third with unicode पांचाल"}}

--- a/tests/data/sample.ndjson
+++ b/tests/data/sample.ndjson
@@ -1,0 +1,3 @@
+{"id": 1, "name": "First"}
+{"id": 2, "name": "Second"}
+{"id": 3, "name": "Third with unicode पांचाल"}


### PR DESCRIPTION
This PR changes the approach towards testing in `test_agnostic_load_file.py`.

Before, all the tests would heavily rely on `unittest.TestCase`. Since we are using Pytest, this can be a bit limiting (https://docs.pytest.org/en/6.2.x/unittest.html#pytest-features-in-unittest-testcase-subclasses), since it doesn't allow us to use features such as [parametrization](https://docs.pytest.org/en/6.2.x/example/parametrize.html).

I believe we can benefit by using parametrization, since it has the perspective of allowing us to have less code to maintain, while having a pattern to validate our combinations of parameters (eg. multiple input file types, databases, multiple transport layers, etc).

Work in progress: I'll extent the scope of this PR so we also cover writing to `json` / `ndjson`.