### PR TITLE
Sql alchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,4 +472,3 @@ from astro.ml import predict
 def my_df_func():
     return pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
 ```
-

--- a/ci-test-connections.yaml
+++ b/ci-test-connections.yaml
@@ -7,6 +7,14 @@ connections:
     password: postgres
     port: 5432
     extra:
+  - conn_id: postgres_sqla_conn
+    conn_type: postgresql
+    host: localhost
+    schema:
+    login: postgres
+    password: postgres
+    port: 5432
+    extra:
   - conn_id: snowflake_conn
     conn_type: snowflake
     host: https://gp21411.us-east-1.snowflakecomputing.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "snowflake-sqlalchemy ==1.2.0",
     "snowflake-connector-python[pandas]",
     "smart-open[all]>=5.2.1",
+    "SQLAlchemy == 1.4.28"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator"]

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -13,7 +13,6 @@ from astro.sql.operators.sql_decorator import SqlDecoratoratedOperator
 from astro.sql.table import Table
 from astro.utils.snowflake_merge_func import is_valid_snow_identifier
 
-
 class Check:
     def __init__(
         self,

--- a/src/astro/utils/load_dataframe.py
+++ b/src/astro/utils/load_dataframe.py
@@ -36,6 +36,7 @@ def move_dataframe_to_sql(
 ):
     # Select database Hook based on `conn` type
     hook: Union[TempPostgresHook, TempSnowflakeHook] = {  # type: ignore
+        "postgresql": TempPostgresHook(postgres_conn_id=conn_id, schema=database),
         "postgres": TempPostgresHook(postgres_conn_id=conn_id, schema=database),
         "snowflake": TempSnowflakeHook(
             snowflake_conn_id=conn_id,

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -6,7 +6,7 @@ from psycopg2 import sql
 
 def set_schema_query(conn_type, hook, schema_id, user):
 
-    if conn_type == "postgres":
+    if conn_type == "postgresql" or conn_type == "postgres":
         return (
             sql.SQL("CREATE SCHEMA IF NOT EXISTS {schema} AUTHORIZATION {user}")
             .format(schema=sql.Identifier(schema_id), user=sql.Identifier(user))

--- a/tests/operators/test_agnostic_stats_check.py
+++ b/tests/operators/test_agnostic_stats_check.py
@@ -36,7 +36,7 @@ class TestStatsCheckOperator(unittest.TestCase):
             path=str(cls.cwd) + "/../data/homes.csv",
             output_table=Table(
                 "stats_check_test_1",
-                conn_id="postgres_conn",
+                conn_id="postgres_sqla_conn",
                 database="pagila",
                 schema="public",
             ),
@@ -45,7 +45,7 @@ class TestStatsCheckOperator(unittest.TestCase):
             path=str(cls.cwd) + "/../data/homes2.csv",
             output_table=Table(
                 "stats_check_test_2",
-                conn_id="postgres_conn",
+                conn_id="postgres_sqla_conn",
                 database="pagila",
                 schema="public",
             ),
@@ -54,7 +54,7 @@ class TestStatsCheckOperator(unittest.TestCase):
             path=str(cls.cwd) + "/../data/homes3.csv",
             output_table=Table(
                 "stats_check_test_3",
-                conn_id="postgres_conn",
+                conn_id="postgres_sqla_conn",
                 database="pagila",
                 schema="public",
             ),
@@ -140,13 +140,13 @@ class TestStatsCheckOperator(unittest.TestCase):
                 main_table=Table(
                     "stats_check_test_1",
                     database="pagila",
-                    conn_id="postgres_conn",
+                    conn_id="postgres_sqla_conn",
                     schema="public",
                 ),
                 compare_table=Table(
                     "stats_check_test_2",
                     database="pagila",
-                    conn_id="postgres_conn",
+                    conn_id="postgres_sqla_conn",
                     schema="public",
                 ),
                 checks=[aql.OutlierCheck("room_check", {"rooms": "rooms"}, 2, 0.0)],
@@ -163,13 +163,13 @@ class TestStatsCheckOperator(unittest.TestCase):
                 main_table=Table(
                     "stats_check_test_1",
                     database="pagila",
-                    conn_id="postgres_conn",
+                    conn_id="postgres_sqla_conn",
                     schema="public",
                 ),
                 compare_table=Table(
                     "stats_check_test_3",
                     database="pagila",
-                    conn_id="postgres_conn",
+                    conn_id="postgres_sqla_conn",
                     schema="public",
                 ),
                 checks=[aql.OutlierCheck("room_check", {"rooms": "rooms"}, 2, 0.0)],


### PR DESCRIPTION
Added SQLAlchemy as a middle layer to build and convert SQL to required DB dialects(supported dialects - https://docs.sqlalchemy.org/en/14/dialects/).

Interesting supported dialects:
1. Postgres
2. Snowflake
3. Bigquery
4. Redshift

Summary of changes:
1. Modified sql_decorator to be able to support both string sql and sql alchemy objects.
2. Updated stats_check op to use SQLAlchemy instead of creating sql queries. (much less code now!).
