### PR TITLE
Add support to save_file from json/ndjson

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,13 @@
 import os
-import pathlib
 
 import pytest
-
-# Import Operator
 import yaml
-from airflow.models import Connection, DagRun
+from airflow.models import DAG, Connection, DagRun
 from airflow.models import TaskInstance as TI
+from airflow.utils import timezone
 from airflow.utils.session import create_session
 
-from astro import sql as aql
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -26,3 +24,11 @@ def create_database_connections():
         session.query(Connection).delete()
         for conn in connections:
             session.add(conn)
+
+
+@pytest.fixture
+def sample_dag():
+    yield DAG("test_dag", default_args={"owner": "airflow", "start_date": DEFAULT_DATE})
+    with create_session() as session:
+        session.query(DagRun).delete()
+        session.query(TI).delete()

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -130,11 +130,13 @@ class SaveFile(BaseOperator):
         serialiser = {
             "parquet": df.to_parquet,
             "csv": df.to_csv,
-            # "json": pd.to_json,
-            # "ndjson": pd.to_json,
+            "json": df.to_json,
+            "ndjson": df.to_json,
         }
         serialiser_params = {
-            # "ndjson": {"lines": True}
+            "csv": {"index": False},
+            "json": {"orient": "records"},
+            "ndjson": {"orient": "records", "lines": True},
         }
         with open(
             output_file_path, mode="wb", transport_params=transport_params


### PR DESCRIPTION
Bonus:
- Refactor save_file tests, now validating all currently supported DBs and file formats
- Fix CSV save_file, which was previously exporting Pandas' indices