### PR TITLE
#69 Fix issue with inheritance in aql.render

### DIFF
--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -65,8 +65,8 @@ class AgnosticBooleanCheck(SqlDecoratoratedOperator):
         **kwargs,
     ):
         """
-        :param table: table name
-        :type table: str
+        :param table: table to check
+        :type table: Table
         :param checks: check class object, which represent boolean expression
         :type checks: Check
         :param max_rows_returned: number of row returned if the check fails.

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -166,6 +166,10 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         """
         if self.conn_type == "postgres" and self.schema:
             output_table_name = self.schema + "." + output_table_name
+        elif self.conn_type == "snowflake" and self.schema and "." not in self.sql:
+            output_table_name = (
+                self.database + "." + self.schema + "." + output_table_name
+            )
         return output_table_name
 
     def _set_variables_from_first_table(self):
@@ -309,7 +313,7 @@ class SqlDecoratoratedOperator(DecoratedOperator):
             self.sql = postgres_transform.parse_template(self.sql)
         else:
             self.sql = snowflake_transform._parse_template(
-                self.sql, self.python_callable
+                self.sql, self.python_callable, self.parameters
             )
 
     def _cleanup(self):

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -161,7 +161,7 @@ class SqlDecoratoratedOperator(DecoratedOperator):
             self.log.info(f"returning table {self.output_table}")
             return self.output_table
 
-    def handle_schema(self, output_table_name, schema=get_schema()):
+    def handle_schema(self, output_table_name, schema=None):
         """
         In postgres, we set the schema in the query itself instead of as a query parameter.
         This function adds the necessary {schema}.{table} notation.
@@ -169,6 +169,7 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         :param output_table_name:
         :return:
         """
+        schema = schema or get_schema()
         if self.conn_type == "postgres" and self.schema:
             output_table_name = schema + "." + output_table_name
         elif self.conn_type == "snowflake" and self.schema and "." not in self.sql:

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -120,10 +120,12 @@ class SqlDecoratoratedOperator(DecoratedOperator):
 
             if not self.output_table:
                 output_table_name = create_table_name(context=context)
-                full_output_table_name = self.handle_schema(output_table_name)
+                full_output_table_name = self.handle_output_table_schema(
+                    output_table_name
+                )
             else:
                 output_table_name = self.output_table.table_name
-                full_output_table_name = self.handle_schema(
+                full_output_table_name = self.handle_output_table_schema(
                     output_table_name, self.output_table.schema
                 )
 
@@ -161,12 +163,12 @@ class SqlDecoratoratedOperator(DecoratedOperator):
             self.log.info(f"returning table {self.output_table}")
             return self.output_table
 
-    def handle_schema(self, output_table_name, schema=None):
+    def handle_output_table_schema(self, output_table_name, schema=None):
         """
         In postgres, we set the schema in the query itself instead of as a query parameter.
         This function adds the necessary {schema}.{table} notation.
-        :param schema:
         :param output_table_name:
+        :param schema: an optional schema if the output_table has a schema set. Defaults to the temp schema
         :return:
         """
         schema = schema or get_schema()

--- a/src/astro/sql/parsers/sql_directory_parser.py
+++ b/src/astro/sql/parsers/sql_directory_parser.py
@@ -116,4 +116,4 @@ class ParsedSqlOperator(SqlDecoratoratedOperator):
         )
 
     def execute(self, context: Dict):
-        super().execute(context)
+        return super().execute(context)

--- a/src/astro/utils/snowflake_append.py
+++ b/src/astro/utils/snowflake_append.py
@@ -34,11 +34,11 @@ def snowflake_append_func(
 
     if columns or casted_columns:
         statement = (
-            "INSERT INTO Identifier(%(main_table)s) ({main_cols}{sep}{main_casted_cols})"
-            "(SELECT {fields}{sep}{casted_fields} FROM Identifier(%(append_table)s))"
+            "INSERT INTO %(main_table)s ({main_cols}{sep}{main_casted_cols})"
+            "(SELECT {fields}{sep}{casted_fields} FROM %(append_table)s)"
         )
     else:
-        statement = "INSERT INTO Identifier(%(main_table)s) (SELECT * FROM Identifier(%(append_table)s))"
+        statement = "INSERT INTO %(main_table)s (SELECT * FROM %(append_table)s)"
 
     col_dict = {
         f"col{i}": x for i, x in enumerate(columns)

--- a/src/astro/utils/snowflake_merge_func.py
+++ b/src/astro/utils/snowflake_merge_func.py
@@ -43,10 +43,7 @@ def snowflake_merge_func(
     merge_columns,
     conflict_strategy,
 ):
-    statement = (
-        "merge into Identifier(%(main_table)s) using Identifier(%(merge_table)s) on "
-        "{merge_clauses}"
-    )
+    statement = "merge into %(main_table)s using %(merge_table)s on " "{merge_clauses}"
 
     merge_target_dict = {
         "merge_clause_target_" + str(i): target_table.table_name + "." + x

--- a/src/astro/utils/snowflake_transform.py
+++ b/src/astro/utils/snowflake_transform.py
@@ -19,17 +19,23 @@ import re
 from astro.sql.table import Table
 
 
-def handle_table(t: Table):
+def _handle_table(t: Table):
+    """
+    If the table is a fully qualified name ("DATABASE"."SCHEMA"."TABLE") thenw e do nothing, otherwise
+    we generate a fully qualified name. This will allow snowflake users to do cross schema and cross database queries
+    :param t:
+    :return:
+    """
     return (
         t.database + "." + t.schema + "." + t.table_name
-        if t.schema and "." not in t.table_name
+        if t.schema and t.table_name.count(".") > 1
         else t.table_name
     )
 
 
 def process_params(parameters):
     return {
-        k: (handle_table(v) if type(v) == Table else v) for k, v in parameters.items()
+        k: (_handle_table(v) if type(v) == Table else v) for k, v in parameters.items()
     }
 
 

--- a/src/astro/utils/snowflake_transform.py
+++ b/src/astro/utils/snowflake_transform.py
@@ -21,16 +21,13 @@ from astro.sql.table import Table
 
 def _handle_table(t: Table):
     """
-    If the table is a fully qualified name ("DATABASE"."SCHEMA"."TABLE") thenw e do nothing, otherwise
-    we generate a fully qualified name. This will allow snowflake users to do cross schema and cross database queries
+    returns the fully qualified name ("DATABASE"."SCHEMA"."TABLE").
+    This will allow snowflake users to do cross schema and cross database queries
     :param t:
     :return:
     """
-    return (
-        t.database + "." + t.schema + "." + t.table_name
-        if t.schema and t.table_name.count(".") > 1
-        else t.table_name
-    )
+
+    return t.database + "." + t.schema + "." + t.table_name
 
 
 def process_params(parameters):

--- a/src/astro/utils/snowflake_transform.py
+++ b/src/astro/utils/snowflake_transform.py
@@ -21,7 +21,7 @@ from astro.sql.table import Table
 
 def handle_table(t: Table):
     return (
-        t.schema + "." + t.table_name
+        t.database + "." + t.schema + "." + t.table_name
         if t.schema and "." not in t.table_name
         else t.table_name
     )
@@ -35,7 +35,7 @@ def process_params(parameters):
 
 def _parse_template(sql, python_callable, added_parameters):
     param_types = inspect.signature(python_callable).parameters.copy()
-    param_types = {k: v.annotation for k, v in param_types}
+    param_types = {k: v.annotation for k, v in param_types.items()}
     added_parameters = {k: type(v) for k, v in added_parameters.items()}
     param_types.update(added_parameters)
     sql = sql.replace("{", "%(").replace("}", ")s")

--- a/tests/operators/test_snowflake_decorator.py
+++ b/tests/operators/test_snowflake_decorator.py
@@ -75,6 +75,9 @@ class TestSnowflakeOperator(unittest.TestCase):
         cls.snowflake_table = test_utils.get_table_name(
             "SNOWFLAKE_TRANSFORM_TEST_TABLE"
         )
+        cls.snow_inherit_table = test_utils.get_table_name(
+            "SNOWFLAKE_INHERIT_TEST_TABLE"
+        )
         cls.snowflake_table_raw_sql = test_utils.get_table_name(
             "SNOWFLAKE_TRANSFORM_RAW_SQL_TEST_TABLE"
         )
@@ -83,6 +86,13 @@ class TestSnowflakeOperator(unittest.TestCase):
     def tearDownClass(cls):
         test_utils.drop_table_snowflake(
             table_name=cls.snowflake_table,
+            schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            database=os.getenv("SNOWFLAKE_DATABASE"),
+            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            conn_id="snowflake_conn",
+        )
+        test_utils.drop_table_snowflake(
+            table_name=cls.snow_inherit_table,
             schema=os.getenv("SNOWFLAKE_SCHEMA"),
             database=os.getenv("SNOWFLAKE_DATABASE"),
             warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
@@ -142,7 +152,7 @@ class TestSnowflakeOperator(unittest.TestCase):
     def test_snowflake_query(self):
         @aql.transform
         def sample_snow(input_table: Table):
-            return f"SELECT * FROM {input_table.table_name} LIMIT 10"
+            return "SELECT * FROM {input_table} LIMIT 10"
 
         hook = get_snowflake_hook()
         drop_table(
@@ -166,10 +176,20 @@ class TestSnowflakeOperator(unittest.TestCase):
                     warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
                 ),
             )
+            x = sample_snow(
+                input_table=f,
+                output_table=Table(
+                    self.snow_inherit_table,
+                    conn_id="snowflake_conn",
+                    schema=os.getenv("SNOWFLAKE_SCHEMA"),
+                    database=os.getenv("SNOWFLAKE_DATABASE"),
+                    warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                ),
+            )
         test_utils.run_dag(self.dag)
 
         df = hook.get_pandas_df(
-            f'SELECT * FROM "{os.getenv("SNOWFLAKE_DATABASE")}"."{os.getenv("SNOWFLAKE_SCHEMA")}"."{self.snowflake_table}"'
+            f'SELECT * FROM "{os.getenv("SNOWFLAKE_DATABASE")}"."{os.getenv("SNOWFLAKE_SCHEMA")}"."{self.snow_inherit_table}"'
         )
         assert len(df) == 10
 
@@ -184,7 +204,7 @@ class TestSnowflakeOperator(unittest.TestCase):
             conn_id="snowflake_conn",
         )
         def sample_snow(my_input_table: Table, snowflake_table_raw_sql: str):
-            return f"CREATE TABLE {snowflake_table_raw_sql} AS (SELECT * FROM {my_input_table.table_name} LIMIT 5)"
+            return "CREATE TABLE {snowflake_table_raw_sql} AS (SELECT * FROM {my_input_table} LIMIT 5)"
 
         with self.dag:
             f = sample_snow(

--- a/tests/operators/test_snowflake_decorator.py
+++ b/tests/operators/test_snowflake_decorator.py
@@ -203,8 +203,10 @@ class TestSnowflakeOperator(unittest.TestCase):
         @aql.run_raw_sql(
             conn_id="snowflake_conn",
         )
-        def sample_snow(my_input_table: Table, snowflake_table_raw_sql: str):
-            return "CREATE TABLE {snowflake_table_raw_sql} AS (SELECT * FROM {my_input_table} LIMIT 5)"
+        def sample_snow(
+            my_input_table: Table, snowflake_table_raw_sql: Table, num_rows: int
+        ):
+            return "CREATE TABLE {snowflake_table_raw_sql} AS (SELECT * FROM {my_input_table} LIMIT {num_rows})"
 
         with self.dag:
             f = sample_snow(
@@ -215,7 +217,14 @@ class TestSnowflakeOperator(unittest.TestCase):
                     database=os.getenv("SNOWFLAKE_DATABASE"),
                     warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
                 ),
-                snowflake_table_raw_sql=self.snowflake_table_raw_sql,
+                snowflake_table_raw_sql=Table(
+                    self.snowflake_table_raw_sql,
+                    conn_id="snowflake_conn",
+                    schema=os.getenv("SNOWFLAKE_SCHEMA"),
+                    database=os.getenv("SNOWFLAKE_DATABASE"),
+                    warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                ),
+                num_rows=5,
             )
         test_utils.run_dag(self.dag)
 

--- a/tests/operators/test_snowflake_merge_func.py
+++ b/tests/operators/test_snowflake_merge_func.py
@@ -105,8 +105,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into Identifier(%(main_table)s) using Identifier(%(merge_table)s) "
+            sql == "merge into %(main_table)s using %(merge_table)s "
             "on Identifier(%(merge_clause_target_0)s)=Identifier(%(merge_clause_append_0)s) "
             f"when matched then UPDATE SET {self.main_table_name}.sell={self.merge_table_name}.sell "
             f"when not matched then insert({self.main_table_name}.sell) values ({self.merge_table_name}.sell)"
@@ -129,8 +128,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into Identifier(%(main_table)s) using Identifier(%(merge_table)s) "
+            sql == "merge into %(main_table)s using %(merge_table)s "
             "on Identifier(%(merge_clause_target_0)s)=Identifier(%(merge_clause_append_0)s) AND "
             "Identifier(%(merge_clause_target_1)s)=Identifier(%(merge_clause_append_1)s) "
             f"when matched then UPDATE SET {self.main_table_name}.sell={self.merge_table_name}.sell "
@@ -156,8 +154,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into Identifier(%(main_table)s) using Identifier(%(merge_table)s) "
+            sql == "merge into %(main_table)s using %(merge_table)s "
             "on Identifier(%(merge_clause_target_0)s)=Identifier(%(merge_clause_append_0)s) "
             f"when not matched then insert({self.main_table_name}.sell) values ({self.merge_table_name}.sell)"
         )

--- a/tests/parsers/single_task_dag/agg_orders.sql
+++ b/tests/parsers/single_task_dag/agg_orders.sql
@@ -1,0 +1,7 @@
+---
+conn_id: snowflake_conn
+database: DWH_LEGACY
+warehouse: TRANSFORMING
+schema: SANDBOX_AIRFLOW_TEST
+---
+SELECT * FROM ADOPTION_CENTER_1

--- a/tests/parsers/single_task_dag/inherit_task.sql
+++ b/tests/parsers/single_task_dag/inherit_task.sql
@@ -1,0 +1,8 @@
+---
+conn_id: snowflake_conn
+database: DWH_LEGACY
+warehouse: TRANSFORMING
+template_vars:
+    foo: agg_orders
+---
+SELECT * FROM foo

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -98,3 +98,10 @@ class TestSQLParsing(unittest.TestCase):
             new_customers_table.operator.sql
             == "SELECT * FROM {customers_table} WHERE member_since > DATEADD(day, -7, '{{ execution_date }}')"
         )
+
+    def test_parse_creates_xcom(self):
+        with self.dag:
+            rendered_tasks = aql.render(dir_path + "/single_task_dag")
+        from tests.operators import utils as test_utils
+
+        test_utils.run_dag(self.dag)

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -11,6 +11,7 @@ from airflow.utils.session import create_session
 # Import Operator
 import astro.sql as aql
 from astro.sql.table import Table
+from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
@@ -100,8 +101,11 @@ class TestSQLParsing(unittest.TestCase):
         )
 
     def test_parse_creates_xcom(self):
+        """
+        Runs two tasks with a direct dependency, the DAG will fail if task two can not inherit the table produced by task 1
+        :return:
+        """
         with self.dag:
             rendered_tasks = aql.render(dir_path + "/single_task_dag")
-        from tests.operators import utils as test_utils
 
         test_utils.run_dag(self.dag)


### PR DESCRIPTION
There were three primary issues with aql.render where the DAGs were
showing up in the graph view properly but were not running properly when
tasks inherit from eachother.

1. We were not properly returning the result which meant that the Table
   object was not being saved to XCOM
2. (snowflake specific) There was an issue in how we would parse
   snowflake parameters that prevented them from properly overwriting
   parameters in the SQL statement.
3. There was a bug in snowflake when attempting to handle multiple
   schemas at the same time.