### PR TITLE
Allow downstream tasks to inherit context from params

### DIFF
--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -197,6 +197,13 @@ class SqlDecoratoratedOperator(DecoratedOperator):
             ]
             if table_kwargs:
                 first_table = self.op_kwargs[table_kwargs[0].name]
+
+        # If there is no first table via op_ags or kwargs, we check the parameters
+        if not first_table:
+            param_tables = [t for t in self.parameters.values() if type(t) == Table]
+            if param_tables:
+                first_table = param_tables[0]
+
         if first_table:
             self.conn_id = first_table.conn_id or self.conn_id
             self.database = first_table.database or self.database

--- a/tests/parsers/single_task_dag/inherit_task.sql
+++ b/tests/parsers/single_task_dag/inherit_task.sql
@@ -1,7 +1,4 @@
 ---
-conn_id: snowflake_conn
-database: DWH_LEGACY
-warehouse: TRANSFORMING
 template_vars:
     foo: agg_orders
 ---


### PR DESCRIPTION
In cases where a function does not have op_args and op_kwargs, we should
check the parameters returned by the python callable. This is critical
for aql.render