### PR TITLE
Fix converting SQL to DF if there is a '.' in table name.

### DIFF
--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -105,7 +105,7 @@ class AgnosticBooleanCheck(SqlDecoratoratedOperator):
     def prep_boolean_checks_query(table: Table, checks: List[Check]):
         temp_table = (
             select([check.get_expression() for check in checks])
-            .select_from(text(table.qualified_name()))
+            .select_from(text(table.fully_qualified_name()))
             .alias("check_table")
         )
         return select([check.get_result() for check in checks]).select_from(temp_table)
@@ -113,7 +113,7 @@ class AgnosticBooleanCheck(SqlDecoratoratedOperator):
     def prep_results(self, results):
         return (
             select(["*"])
-            .select_from(text(self.table.qualified_name()))
+            .select_from(text(self.table.fully_qualified_name()))
             .where(and_(*[text(self.checks[index].expression) for index in results]))
             .limit(self.max_rows_returned)
         )

--- a/src/astro/sql/operators/sql_dataframe.py
+++ b/src/astro/sql/operators/sql_dataframe.py
@@ -141,8 +141,11 @@ class SqlDataframeOperator(DecoratedOperator):
                 postgres_conn_id=table.conn_id, schema=table.database
             )
             query = (
-                sql.SQL("SELECT * FROM {input_table}")
-                .format(input_table=sql.Identifier(table.table_name))
+                sql.SQL("SELECT * FROM {schema}.{input_table}")
+                .format(
+                    schema=sql.Identifier(table.schema),
+                    input_table=sql.Identifier(table.table_name.strip('"')),
+                )
                 .as_string(self.hook.get_conn())
             )
             return self.hook.get_pandas_df(query)
@@ -151,5 +154,7 @@ class SqlDataframeOperator(DecoratedOperator):
             hook = self.get_snow_hook(table)
             return hook.get_pandas_df(
                 "SELECT * FROM IDENTIFIER(%(input_table)s)",
-                parameters={"input_table": table.table_name},
+                parameters={
+                    "input_table": table.fully_qualified_name(conn_type="snowflake")
+                },
             )

--- a/src/astro/sql/operators/sql_dataframe.py
+++ b/src/astro/sql/operators/sql_dataframe.py
@@ -154,7 +154,5 @@ class SqlDataframeOperator(DecoratedOperator):
             hook = self.get_snow_hook(table)
             return hook.get_pandas_df(
                 "SELECT * FROM IDENTIFIER(%(input_table)s)",
-                parameters={
-                    "input_table": table.fully_qualified_name(conn_type="snowflake")
-                },
+                parameters={"input_table": table.fully_qualified_name()},
             )

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -132,6 +132,8 @@ class SqlDecoratoratedOperator(DecoratedOperator):
                     warehouse=self.warehouse,
                     schema=get_schema(),
                 )
+            self.output_table.conn_id = self.output_table.conn_id or self.conn_id
+            self.output_table.database = self.output_table.database or self.database
             full_output_table_name = self.output_table.fully_qualified_name(
                 schema=self.schema
             )

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -133,7 +133,7 @@ class SqlDecoratoratedOperator(DecoratedOperator):
                     schema=get_schema(),
                 )
             full_output_table_name = self.output_table.fully_qualified_name(
-                conn_type=self.conn_type, schema=self.schema
+                schema=self.schema
             )
 
             self.sql = self.create_temporary_table(self.sql, full_output_table_name)

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -36,8 +36,21 @@ class Table:
     def identifier_args(self):
         return (self.schema, self.table_name) if self.schema else (self.table_name,)
 
-    def qualified_name(self):
-        return self.schema + "." + self.table_name if self.schema else self.table_name
+    def fully_qualified_name(self, conn_type, schema=None):
+        """
+        In postgres, we set the schema in the query itself instead of as a query parameter.
+        This function adds the necessary {schema}.{table} notation.
+        :param output_table_name:
+        :param schema: an optional schema if the output_table has a schema set. Defaults to the temp schema
+        :return:
+        """
+        table_name = self.table_name
+        schema = self.schema or schema
+        if (conn_type == "postgres" or conn_type == "postgresql") and schema:
+            table_name = schema + "." + self.table_name
+        elif conn_type == "snowflake" and schema and "." not in self.table_name:
+            table_name = self.database + "." + schema + "." + self.table_name
+        return table_name
 
     def __str__(self):
         return f"Table(table_name={self.table_name}, database={self.database}, schema={self.schema}, conn_id={self.conn_id}, warehouse={self.warehouse})"

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -27,10 +27,12 @@ class Table:
         warehouse=None,
         role=None,
     ):
+        from astro.utils.schema_util import get_schema
+
         self.table_name = table_name
         self.conn_id = conn_id
         self.database = database
-        self.schema = schema
+        self.schema = schema or get_schema()
         self.warehouse = warehouse
         self.conn_type = BaseHook.get_connection(self.conn_id).conn_type
         self.role = role

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -38,9 +38,10 @@ class Table:
 
     def fully_qualified_name(self, conn_type, schema=None):
         """
-        In postgres, we set the schema in the query itself instead of as a query parameter.
-        This function adds the necessary {schema}.{table} notation.
-        :param output_table_name:
+        To make our SQL queries more clear in scope and to allow queries containing multiple
+        schemas or databases, we should start generating SQL that uses fully qualified names (eg.
+        schema.table in postgres and DATABASE.SCHEMA.TABLE in snowflake).
+        :param conn_type: What type of connection are we creating.
         :param schema: an optional schema if the output_table has a schema set. Defaults to the temp schema
         :return:
         """

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -49,6 +49,7 @@ class Table:
         :param schema: an optional schema if the output_table has a schema set. Defaults to the temp schema
         :return:
         """
+        self.conn_type = BaseHook.get_connection(self.conn_id).conn_type
         table_name = self.table_name
         schema = self.schema or schema
         if (self.conn_type == "postgres" or self.conn_type == "postgresql") and schema:

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -26,5 +26,5 @@ def get_schema():
 def get_table_name(table: Table):
     conn_type = BaseHook.get_connection(table.conn_id).conn_type
     if conn_type in ["bigquery"]:
-        return table.qualified_name()
+        return table.fully_qualified_name()
     return table.table_name

--- a/tests/operators/test_agnostic_boolean_check.py
+++ b/tests/operators/test_agnostic_boolean_check.py
@@ -130,6 +130,7 @@ class TestBooleanCheckOperator(unittest.TestCase):
                     self.table,
                     database="pagila",
                     conn_id="postgres_conn",
+                    schema="public",
                 ),
                 checks=[Check("test_1", f"{self.table}.rooms > 3")],
                 max_rows_returned=10,
@@ -146,6 +147,7 @@ class TestBooleanCheckOperator(unittest.TestCase):
                     self.table,
                     database="pagila",
                     conn_id="postgres_conn",
+                    schema="public",
                 ),
                 checks=[
                     Check("test_1", f"{self.table}.rooms > 7"),

--- a/tests/operators/test_agnostic_boolean_check.py
+++ b/tests/operators/test_agnostic_boolean_check.py
@@ -72,7 +72,6 @@ class TestBooleanCheckOperator(unittest.TestCase):
                 cls.table,
                 conn_id="postgres_conn",
                 database="pagila",
-                schema="public",
             ),
         ).operator.execute({"run_id": "foo"})
 

--- a/tests/operators/test_dataframe.py
+++ b/tests/operators/test_dataframe.py
@@ -117,7 +117,11 @@ class TestDataframeFromSQL(unittest.TestCase):
         res = self.create_and_run_task(
             my_df_func,
             (),
-            {"df": Table("actor", conn_id="postgres_conn", database="pagila")},
+            {
+                "df": Table(
+                    "actor", conn_id="postgres_conn", database="pagila", schema="public"
+                )
+            },
         )
         assert (
             XCom.get_one(
@@ -133,7 +137,11 @@ class TestDataframeFromSQL(unittest.TestCase):
 
         res = self.create_and_run_task(
             my_df_func,
-            (Table("actor", conn_id="postgres_conn", database="pagila"),),
+            (
+                Table(
+                    "actor", conn_id="postgres_conn", database="pagila", schema="public"
+                ),
+            ),
             {},
         )
         assert (
@@ -150,8 +158,16 @@ class TestDataframeFromSQL(unittest.TestCase):
 
         res = self.create_and_run_task(
             my_df_func,
-            (Table("actor", conn_id="postgres_conn", database="pagila"),),
-            {"film_df": Table("film", conn_id="postgres_conn", database="pagila")},
+            (
+                Table(
+                    "actor", conn_id="postgres_conn", database="pagila", schema="public"
+                ),
+            ),
+            {
+                "film_df": Table(
+                    "film", conn_id="postgres_conn", database="pagila", schema="public"
+                )
+            },
         )
         assert (
             XCom.get_one(

--- a/tests/operators/test_postgres_append.py
+++ b/tests/operators/test_postgres_append.py
@@ -173,7 +173,7 @@ class TestPostgresAppend(unittest.TestCase):
         self.wait_for_task_finish(dr, foo.task_id)
 
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name()}",
             con=hook.get_conn(),
         )
 
@@ -216,7 +216,7 @@ class TestPostgresAppend(unittest.TestCase):
         foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         self.wait_for_task_finish(dr, foo.task_id)
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name()}",
             con=hook.get_conn(),
         )
 
@@ -261,7 +261,7 @@ class TestPostgresAppend(unittest.TestCase):
         foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         self.wait_for_task_finish(dr, foo.task_id)
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name()}",
             con=hook.get_conn(),
         )
 
@@ -308,7 +308,7 @@ class TestPostgresAppend(unittest.TestCase):
         self.wait_for_task_finish(dr, foo.task_id)
 
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name()}",
             con=hook.get_conn(),
         )
 

--- a/tests/operators/test_postgres_append.py
+++ b/tests/operators/test_postgres_append.py
@@ -173,7 +173,7 @@ class TestPostgresAppend(unittest.TestCase):
         self.wait_for_task_finish(dr, foo.task_id)
 
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
             con=hook.get_conn(),
         )
 
@@ -216,7 +216,7 @@ class TestPostgresAppend(unittest.TestCase):
         foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         self.wait_for_task_finish(dr, foo.task_id)
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
             con=hook.get_conn(),
         )
 
@@ -261,7 +261,7 @@ class TestPostgresAppend(unittest.TestCase):
         foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         self.wait_for_task_finish(dr, foo.task_id)
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
             con=hook.get_conn(),
         )
 
@@ -308,7 +308,7 @@ class TestPostgresAppend(unittest.TestCase):
         self.wait_for_task_finish(dr, foo.task_id)
 
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
+            f"SELECT * FROM {load_main.operator.output_table.fully_qualified_name(conn_type='postgres')}",
             con=hook.get_conn(),
         )
 

--- a/tests/operators/test_postgres_decorator.py
+++ b/tests/operators/test_postgres_decorator.py
@@ -148,7 +148,10 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "input_table": Table(
-                    table_name="actor", conn_id="postgres_conn", database="pagila"
+                    table_name="actor",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 ),
             },
         )
@@ -209,7 +212,10 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "input_table": Table(
-                    table_name="actor", conn_id="postgres_conn", database="pagila"
+                    table_name="actor",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 ),
             },
         )
@@ -234,7 +240,10 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "input_table": Table(
-                    table_name="actor", conn_id="postgres_conn", database="pagila"
+                    table_name="actor",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 ),
             },
         )
@@ -252,7 +261,7 @@ class TestPostgresDecorator(unittest.TestCase):
             }
 
         self.create_and_run_task(
-            sample_pg, (), {"input_table": Table(table_name="actor")}
+            sample_pg, (), {"input_table": Table(table_name="actor", schema="public")}
         )
 
     def test_postgres_with_jinja_template(self):
@@ -267,7 +276,10 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "input_table": Table(
-                    table_name="rental", conn_id="postgres_conn", database="pagila"
+                    table_name="rental",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 )
             },
         )
@@ -284,7 +296,10 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "input_table": Table(
-                    table_name="rental", conn_id="postgres_conn", database="pagila"
+                    table_name="rental",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 )
             },
         )
@@ -296,7 +311,7 @@ class TestPostgresDecorator(unittest.TestCase):
 
         drop_table(table_name="my_table", postgres_conn=self.hook_target.get_conn())
 
-        @aql.transform(conn_id="postgres_conn", database="pagila")
+        @aql.transform
         def sample_pg(actor: Table, film_actor_join: Table, unsafe_parameter):
             return (
                 "SELECT {actor}.actor_id, first_name, last_name, COUNT(film_id) "
@@ -309,9 +324,12 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "actor": Table(
-                    table_name="actor", conn_id="postgres_conn", database="pagila"
+                    table_name="actor",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 ),
-                "film_actor_join": Table(table_name="film_actor"),
+                "film_actor_join": Table(table_name="film_actor", schema="public"),
                 "unsafe_parameter": "G%%",
                 "output_table": Table("my_table"),
             },
@@ -344,10 +362,11 @@ class TestPostgresDecorator(unittest.TestCase):
             f = aql.transform_file(
                 sql=str(cwd) + "/test.sql",
                 conn_id="postgres_conn",
+                schema="public",
                 database="pagila",
                 parameters={
-                    "actor": Table("actor"),
-                    "film_actor_join": Table("film_actor"),
+                    "actor": Table("actor", schema="public"),
+                    "film_actor_join": Table("film_actor", schema="public"),
                     "unsafe_parameter": "G%%",
                 },
                 output_table=Table("my_table_from_file"),
@@ -392,9 +411,12 @@ class TestPostgresDecorator(unittest.TestCase):
             (),
             {
                 "actor": Table(
-                    table_name="actor", conn_id="postgres_conn", database="pagila"
+                    table_name="actor",
+                    conn_id="postgres_conn",
+                    database="pagila",
+                    schema="public",
                 ),
-                "film_actor_join": Table(table_name="film_actor"),
+                "film_actor_join": Table(table_name="film_actor", schema="public"),
                 "unsafe_parameter": "G%%",
                 "output_table_name": "my_table",
             },

--- a/tests/operators/test_snowflake_append.py
+++ b/tests/operators/test_snowflake_append.py
@@ -156,14 +156,14 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         self.run_append_func([], {})
         main_table_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         assert (
             main_table_count[0]["COUNT(*)"]
@@ -173,15 +173,15 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_no_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         self.run_append_func(["beds", "acres"], {})
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]
@@ -191,15 +191,15 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_with_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         self.run_append_func(["beds"], {"acres": "FLOAT"})
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]
@@ -209,10 +209,10 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_with_cast_and_no_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.qualified_name()}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
 
         self.run_append_func(
@@ -221,7 +221,7 @@ class TestSnowflakeAppend(unittest.TestCase):
         )
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.qualified_name()}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]

--- a/tests/operators/test_snowflake_append.py
+++ b/tests/operators/test_snowflake_append.py
@@ -156,14 +156,14 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name()}"
         )
         self.run_append_func([], {})
         main_table_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
         assert (
             main_table_count[0]["COUNT(*)"]
@@ -173,15 +173,15 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_no_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name()}"
         )
         self.run_append_func(["beds", "acres"], {})
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]
@@ -191,15 +191,15 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_with_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name()}"
         )
         self.run_append_func(["beds"], {"acres": "FLOAT"})
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]
@@ -209,10 +209,10 @@ class TestSnowflakeAppend(unittest.TestCase):
     def test_append_with_cast_and_no_cast(self):
         hook = get_snowflake_hook()
         previous_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
         append_count = hook.run(
-            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT COUNT(*) FROM {self.load_append.operator.output_table.fully_qualified_name()}"
         )
 
         self.run_append_func(
@@ -221,7 +221,7 @@ class TestSnowflakeAppend(unittest.TestCase):
         )
 
         df = hook.get_pandas_df(
-            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name(conn_type='snowflake')}"
+            f"SELECT * FROM {self.load_main.operator.output_table.fully_qualified_name()}"
         )
 
         assert len(df) == previous_count[0]["COUNT(*)"] + append_count[0]["COUNT(*)"]

--- a/tests/parsers/postgres_simple_tasks/test_astro.sql
+++ b/tests/parsers/postgres_simple_tasks/test_astro.sql
@@ -1,0 +1,6 @@
+---
+conn_id: postgres_conn
+database: pagila
+---
+SELECT * FROM actor
+

--- a/tests/parsers/postgres_simple_tasks/test_inheritance.sql
+++ b/tests/parsers/postgres_simple_tasks/test_inheritance.sql
@@ -1,0 +1,6 @@
+---
+template_vars:
+    my_astro_table: test_astro
+---
+SELECT * FROM my_astro_table LIMIT 10
+

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -109,3 +109,22 @@ class TestSQLParsing(unittest.TestCase):
             rendered_tasks = aql.render(dir_path + "/single_task_dag")
 
         test_utils.run_dag(self.dag)
+
+    def test_parse_to_dataframe(self):
+        """
+        Runs two tasks with a direct dependency, the DAG will fail if task two can not inherit the table produced by task 1
+        :return:
+        """
+        import pandas as pd
+
+        from astro.dataframe import dataframe as adf
+
+        @adf
+        def dataframe_func(df: pd.DataFrame):
+            print(df.to_string)
+
+        with self.dag:
+            rendered_tasks = aql.render(dir_path + "/postgres_simple_tasks")
+            dataframe_func(rendered_tasks["test_inheritance"])
+
+        test_utils.run_dag(self.dag)


### PR DESCRIPTION
When converting a postgres SQL table to a dataframe, there is a bug
where if the table has a . in it (e.g. if the task lives within a
taskgroup), then the way that psycopg2 reads the name with the schema
creates a string that sqlalchemy can not parse.