### PR TITLE
Allow passing db context via op_kwargs

### DIFF
--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -68,14 +68,9 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         :param kwargs:
         """
         self.raw_sql = raw_sql
-        self.conn_id = conn_id
         self.autocommit = autocommit
         self.parameters = parameters
-        self.database = database
-        self.schema = schema
         self.handler = handler
-        self.warehouse = warehouse
-        self.role = role
         self.kwargs = kwargs or {}
         self.sql = sql
         self.op_kwargs: Dict = self.kwargs.get("op_kwargs") or {}
@@ -84,11 +79,11 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         else:
             self.output_table = None
 
-        self.database = self.op_kwargs.pop("database", self.database)
-        self.conn_id = self.op_kwargs.pop("conn_id", self.conn_id)
-        self.schema = self.op_kwargs.pop("schema", self.schema)
-        self.warehouse = self.op_kwargs.pop("warehouse", self.warehouse)
-        self.role = self.op_kwargs.pop("role", self.role)
+        self.database = self.op_kwargs.pop("database", database)
+        self.conn_id = self.op_kwargs.pop("conn_id", conn_id)
+        self.schema = self.op_kwargs.pop("schema", schema)
+        self.warehouse = self.op_kwargs.pop("warehouse", warehouse)
+        self.role = self.op_kwargs.pop("role", role)
 
         super().__init__(
             **kwargs,

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -84,6 +84,12 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         else:
             self.output_table = None
 
+        self.database = self.op_kwargs.pop("database", self.database)
+        self.conn_id = self.op_kwargs.pop("conn_id", self.conn_id)
+        self.schema = self.op_kwargs.pop("schema", self.schema)
+        self.warehouse = self.op_kwargs.pop("warehouse", self.warehouse)
+        self.role = self.op_kwargs.pop("role", self.role)
+
         super().__init__(
             **kwargs,
         )
@@ -221,9 +227,10 @@ class SqlDecoratoratedOperator(DecoratedOperator):
 
         # If there is no first table via op_ags or kwargs, we check the parameters
         if not first_table:
-            param_tables = [t for t in self.parameters.values() if type(t) == Table]
-            if param_tables:
-                first_table = param_tables[0]
+            if self.parameters:
+                param_tables = [t for t in self.parameters.values() if type(t) == Table]
+                if param_tables:
+                    first_table = param_tables[0]
 
         if first_table:
             self.conn_id = first_table.conn_id or self.conn_id

--- a/tests/operators/test_postgres_decorator.py
+++ b/tests/operators/test_postgres_decorator.py
@@ -195,6 +195,29 @@ class TestPostgresDecorator(unittest.TestCase):
         )
         assert df.iloc[0].to_dict()["colors"] == "red"
 
+    def test_postgres_set_op_kwargs(self):
+        self.hook_target = PostgresHook(
+            postgres_conn_id="postgres_conn", schema="pagila"
+        )
+
+        @aql.transform
+        def sample_pg():
+            return "SELECT * FROM actor WHERE last_name LIKE 'G%%'"
+
+        self.create_and_run_task(
+            sample_pg,
+            (),
+            {
+                "conn_id": "postgres_conn",
+                "database": "pagila",
+            },
+        )
+        df = pd.read_sql(
+            f"SELECT * FROM tmp_astro.test_dag_sample_pg_1",
+            con=self.hook_target.get_conn(),
+        )
+        assert df.iloc[0].to_dict()["first_name"] == "PENELOPE"
+
     def test_postgres(self):
         self.hook_target = PostgresHook(
             postgres_conn_id="postgres_conn", schema="pagila"

--- a/tests/operators/test_postgres_decorator.py
+++ b/tests/operators/test_postgres_decorator.py
@@ -208,10 +208,8 @@ class TestPostgresDecorator(unittest.TestCase):
             sample_pg,
             (),
             {
-                "op_kwargs": {
-                    "conn_id": "postgres_conn",
-                    "database": "pagila",
-                }
+                "conn_id": "postgres_conn",
+                "database": "pagila",
             },
         )
         df = pd.read_sql(

--- a/tests/operators/test_postgres_decorator.py
+++ b/tests/operators/test_postgres_decorator.py
@@ -208,8 +208,10 @@ class TestPostgresDecorator(unittest.TestCase):
             sample_pg,
             (),
             {
-                "conn_id": "postgres_conn",
-                "database": "pagila",
+                "op_kwargs": {
+                    "conn_id": "postgres_conn",
+                    "database": "pagila",
+                }
             },
         )
         df = pd.read_sql(


### PR DESCRIPTION
For queries where users don't want to pass a table, object, this feature
will allow users to define context at runtime using op_kwargs.

example:

```python
@aql.transform
def test_astro():
    return "SELECT * FROM actor"

with dag:
    actor_table = test_astro(database="pagile", conn_id="my_postgres_conn")
```