### PR TITLE
Replaced bigquery_conn_id with gcp_conn_id, since former is deprecated.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "snowflake-connector-python[pandas]",
     "smart-open[all]>=5.2.1",
     "SQLAlchemy==1.3.24",
-    "sqlalchemy-bigquery==1.3.0"
+    "sqlalchemy-bigquery==1.3.0",
+    "markupsafe>=1.1.1,<2.1.0"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator"]

--- a/tests/operators/utils.py
+++ b/tests/operators/utils.py
@@ -28,7 +28,7 @@ SQL_SERVER_HOOK_PARAMETERS = {
 SQL_SERVER_CONNECTION_KEY = {
     "snowflake": "snowflake_conn_id",
     "postgres": "postgres_conn_id",
-    "bigquery": "bigquery_conn_id",
+    "bigquery": "gcp_conn_id",
 }
 
 SQL_SERVER_HOOK_CLASS = {

--- a/tests/operators/utils.py
+++ b/tests/operators/utils.py
@@ -22,7 +22,7 @@ SQL_SERVER_HOOK_PARAMETERS = {
     },
     "postgres": {"postgres_conn_id": "postgres_conn"},
     "bigquery": {
-        "bigquery_conn_id": "bigquery",
+        "gcp_conn_id": "bigquery",
     },
 }
 SQL_SERVER_CONNECTION_KEY = {


### PR DESCRIPTION
Removed deprecated parameter for BigqueryHook.
