### PR TITLE
Support users who can't create schemas

### DIFF
--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import inspect
+import os
 from builtins import NotImplementedError
 from typing import Callable, Dict, Iterable, Mapping, Optional, Union
 
@@ -29,7 +30,7 @@ from astro.sql.table import Table, create_table_name
 from astro.utils import postgres_transform, snowflake_transform
 from astro.utils.dependencies import BigQueryHook, PostgresHook, SnowflakeHook
 from astro.utils.load_dataframe import move_dataframe_to_sql
-from astro.utils.schema_util import get_schema, set_schema_query
+from astro.utils.schema_util import create_schema_query, get_schema, schema_exists
 
 
 class SqlDecoratoratedOperator(DecoratedOperator):
@@ -95,6 +96,7 @@ class SqlDecoratoratedOperator(DecoratedOperator):
                 return self.handler(cursor)
             return cursor
 
+        self._set_hook()
         self.output_schema = self.schema or get_schema()
         self._set_variables_from_first_table()
 
@@ -116,7 +118,10 @@ class SqlDecoratoratedOperator(DecoratedOperator):
 
         if not self.raw_sql:
             # Create a table name for the temp table
-            self._set_schema_if_needed()
+            if not schema_exists(
+                hook=self.hook, schema=self.schema, conn_type=self.conn_type
+            ):
+                self._set_schema_if_needed()
 
             if not self.output_table:
                 output_table_name = create_table_name(context=context)
@@ -232,23 +237,28 @@ class SqlDecoratoratedOperator(DecoratedOperator):
             self.warehouse = first_table.warehouse or self.warehouse
             self.role = first_table.role or self.role
 
-    def _set_schema_if_needed(self):
-        schema_statement = ""
+    def _set_hook(self):
         if self.conn_type == "postgres":
             self.hook = PostgresHook(
                 postgres_conn_id=self.conn_id, schema=self.database
             )
-            schema_statement = set_schema_query(
+
+        elif self.conn_type == "snowflake":
+            self.hook = self.get_snow_hook()
+
+    def _set_schema_if_needed(self):
+        schema_statement = ""
+        if self.conn_type == "postgres":
+            schema_statement = create_schema_query(
                 conn_type=self.conn_type,
                 hook=self.hook,
                 schema_id=self.schema,
                 user=self.user,
             )
         elif self.conn_type == "snowflake":
-            hook = self.get_snow_hook()
-            schema_statement = set_schema_query(
+            schema_statement = create_schema_query(
                 conn_type=self.conn_type,
-                hook=hook,
+                hook=self.hook,
                 schema_id=self.schema,
                 user=self.user,
             )

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -96,7 +96,6 @@ class SqlDecoratoratedOperator(DecoratedOperator):
                 return self.handler(cursor)
             return cursor
 
-        self._set_hook()
         self.output_schema = self.schema or get_schema()
         self._set_variables_from_first_table()
 
@@ -105,6 +104,8 @@ class SqlDecoratoratedOperator(DecoratedOperator):
         self.schema = self.schema or get_schema()
         self.user = conn.login
         self.run_id = context.get("run_id")
+        self._set_hook()
+
         self.convert_op_arg_dataframes()
         self.convert_op_kwarg_dataframes()
         self.read_sql()

--- a/src/astro/utils/load_dataframe.py
+++ b/src/astro/utils/load_dataframe.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 from typing import Optional, Union
 
 from pandas import DataFrame
@@ -20,7 +21,7 @@ from pandas.io.sql import SQLDatabase
 from snowflake.connector import pandas_tools
 
 from astro.utils.dependencies import BigQueryHook, PostgresHook, SnowflakeHook
-from astro.utils.schema_util import set_schema_query
+from astro.utils.schema_util import create_schema_query, schema_exists
 
 
 def move_dataframe_to_sql(
@@ -51,10 +52,11 @@ def move_dataframe_to_sql(
     if database:
         hook.database = database
 
-    schema_query = set_schema_query(
-        conn_type=conn_type, hook=hook, schema_id=schema, user=user
-    )
-    hook.run(schema_query)
+    if not schema_exists(hook=hook, schema=schema, conn_type=conn_type):
+        schema_query = create_schema_query(
+            conn_type=conn_type, hook=hook, schema_id=schema, user=user
+        )
+        hook.run(schema_query)
     if conn_type == "snowflake":
 
         db = SQLDatabase(engine=hook.get_sqlalchemy_engine())

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -8,7 +8,23 @@ from astro.sql.table import Table
 from astro.utils.dependencies import PostgresHook
 
 
-def set_schema_query(conn_type, hook, schema_id, user):
+def schema_exists(hook, schema, conn_type):
+    if conn_type in ["postgresql", "postgres"]:
+        created_schemas = hook.run(
+            "SELECT schema_name FROM information_schema.schemata;",
+            handler=lambda x: [y[0] for y in x.fetchall()],
+        )
+        return schema in created_schemas
+    elif conn_type == "snowflake":
+        created_schemas = hook.run(
+            "SELECT SCHEMA_NAME from information_schema.schemata;",
+            handler=lambda x: [y[0] for y in x.fetchall()],
+        )
+        return schema in created_schemas
+    return False
+
+
+def create_schema_query(conn_type, hook, schema_id, user):
 
     if conn_type in ["postgresql", "postgres"]:
         return (

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -5,7 +5,6 @@ from airflow.hooks.base import BaseHook
 from psycopg2 import sql
 
 from astro.sql.table import Table
-from astro.utils.dependencies import PostgresHook
 
 
 def schema_exists(hook, schema, conn_type):
@@ -16,10 +15,10 @@ def schema_exists(hook, schema, conn_type):
         )
         return schema in created_schemas
     elif conn_type == "snowflake":
-        created_schemas = hook.run(
-            "SELECT SCHEMA_NAME from information_schema.schemata;",
-            handler=lambda x: [y[0] for y in x.fetchall()],
-        )
+        created_schemas = [
+            x["SCHEMA_NAME"]
+            for x in hook.run("SELECT SCHEMA_NAME from information_schema.schemata;")
+        ]
         return schema in created_schemas
     return False
 


### PR DESCRIPTION
Allow an option where if a user does not have schema creation
permissions they can still use astro (albeit with only pre-created
schemas)

Resolves #120