### PR TITLE
Directly save pandas Dataframes without requiring SQL database

### DIFF
--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -51,4 +51,6 @@ def example_amazon_s3_postgres_load_and_save():
     )
 
 
-dag = example_amazon_s3_postgres_load_and_save()
+example_amazon_s3_postgres_load_and_save_dag = (
+    example_amazon_s3_postgres_load_and_save()
+)

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -45,8 +45,8 @@ def example_amazon_s3_postgres_load_and_save():
     )
 
     aql.save_file(
+        input=t1,
         output_file_path="s3://tmp9/homes.csv",
-        input_table=t1,
         overwrite=True,
     )
 

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -54,7 +54,7 @@ class SaveFile(BaseOperator):
 
     def __init__(
         self,
-        input_table: Optional[Union[Table, pd.DataFrame]] = None,
+        input: Optional[Union[Table, pd.DataFrame]] = None,
         output_file_path="",
         output_conn_id=None,
         output_file_format="csv",
@@ -63,7 +63,7 @@ class SaveFile(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.output_file_path = output_file_path
-        self.input_table = input_table
+        self.input = input
         self.output_conn_id = output_conn_id
         self.overwrite = overwrite
         self.output_file_format = output_file_format
@@ -76,14 +76,14 @@ class SaveFile(BaseOperator):
         """
 
         # Infer db type from `input_conn_id`.
-        if type(self.input_table) == Table:
+        if type(self.input) == Table:
             df = self.convert_sql_table_to_dataframe()
-        elif type(self.input_table) == pd.DataFrame:
-            df = self.input_table
+        elif type(self.input) == pd.DataFrame:
+            df = self.input
         else:
             raise ValueError(
                 "Expected input_table to be Table or dataframe. Got %s",
-                type(self.input_table),
+                type(self.input),
             )
 
         # Write file if overwrite == True or if file doesn't exist.
@@ -109,7 +109,7 @@ class SaveFile(BaseOperator):
             return False
 
     def convert_sql_table_to_dataframe(self):
-        input_table = self.input_table
+        input_table = self.input
         conn_type = BaseHook.get_connection(input_table.conn_id).conn_type
 
         # Select database Hook based on `conn` type

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -46,7 +46,7 @@ class SaveFile(BaseOperator):
     """
 
     template_fields = (
-        "input_table",
+        "input",
         "output_file_path",
         "output_conn_id",
         "output_file_format",

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -192,7 +192,7 @@ class SaveFile(BaseOperator):
 
 def save_file(
     output_file_path,
-    input_table=None,
+    input=None,
     output_conn_id=None,
     overwrite=False,
     output_file_format="csv",
@@ -224,7 +224,7 @@ def save_file(
     return SaveFile(
         task_id=task_id,
         output_file_path=output_file_path,
-        input_table=input_table,
+        input=input,
         output_conn_id=output_conn_id,
         overwrite=overwrite,
         output_file_format=output_file_format,

--- a/tests/operators/test_agnostic_save_file.py
+++ b/tests/operators/test_agnostic_save_file.py
@@ -127,7 +127,7 @@ class TestSaveFile(unittest.TestCase):
         with self.dag:
             df = make_df()
             aql.save_file(
-                input_table=df, output_file_path="/tmp/saved_df.csv", overwrite=True
+                input=df, output_file_path="/tmp/saved_df.csv", overwrite=True
             )
 
         test_utils.run_dag(self.dag)
@@ -151,7 +151,7 @@ class TestSaveFile(unittest.TestCase):
                 save_file,
                 (),
                 {
-                    "input_table": Table(
+                    "input": Table(
                         INPUT_TABLE_NAME,
                         conn_id="postgres_conn",
                         database="pagila",
@@ -188,7 +188,7 @@ class TestSaveFile(unittest.TestCase):
             save_file,
             (),
             {
-                "input_table": Table(
+                "input": Table(
                     INPUT_TABLE_NAME,
                     conn_id="postgres_conn",
                     database="pagila",
@@ -230,7 +230,7 @@ class TestSaveFile(unittest.TestCase):
                 save_file,
                 (),
                 {
-                    "input_table": Table(
+                    "input": Table(
                         INPUT_TABLE_NAME,
                         conn_id="postgres_conn",
                         database="pagila",
@@ -259,7 +259,7 @@ class TestSaveFile(unittest.TestCase):
                     "func": save_file,
                     "op_args": (),
                     "op_kwargs": {
-                        "input_table": Table(
+                        "input": Table(
                             INPUT_TABLE_NAME,
                             conn_id="postgres_conn",
                             database="pagila",
@@ -302,7 +302,7 @@ class TestSaveFile(unittest.TestCase):
             save_file,
             (),
             {
-                "input_table": Table(
+                "input": Table(
                     INPUT_TABLE_NAME,
                     conn_id="bigquery",
                     schema=test_utils.DEFAULT_SCHEMA,
@@ -340,7 +340,7 @@ class TestSaveFile(unittest.TestCase):
             save_file,
             (),
             {
-                "input_table": Table(INPUT_TABLE_NAME, conn_id="sqlite_conn"),
+                "input": Table(INPUT_TABLE_NAME, conn_id="sqlite_conn"),
                 "output_file_path": OUTPUT_FILE_PATH,
                 "output_conn_id": None,
                 "overwrite": True,
@@ -427,7 +427,7 @@ def test_save_file(sample_dag, sql_server, file_type):
         filepath = Path(tmp_dir, f"sample.{file_type}")
 
         task_params = {
-            "input_table": Table(table_name=INPUT_TABLE_NAME, **sql_server_params),
+            "input": Table(table_name=INPUT_TABLE_NAME, **sql_server_params),
             "output_file_path": str(filepath),
             "output_file_format": file_type,
             "output_conn_id": None,


### PR DESCRIPTION
Users who only want to work in pandas dataframes should be able to
save/load those dataframes from the local/cloud storage of their choice
Resolve  #77