### PR TITLE
remove transform file

### DIFF
--- a/docs/OLD_README.md
+++ b/docs/OLD_README.md
@@ -456,26 +456,6 @@ Please note that this is NOT an f string. F-strings in SQL formatting risk secur
 For security, users MUST explicitly identify tables in the function parameters by typing a value as a `Table`. Only then will the SQL decorator treat the value as a table. 
 
 
-### Transform File
-
-Another option for larger SQL queries is to use the `transform_file` function to pass an external SQL file to the DAG.
-All of the same templating will work for this SQL query.
-
-```python
-with self.dag:
-    f = aql.transform_file(
-        sql=str(cwd) + "/my_sql_function.sql",
-        conn_id="postgres_conn",
-        database="pagila",
-        parameters={
-            "actor": Table("actor"),
-            "film_actor_join": Table("film_actor"),
-            "unsafe_parameter": "G%%",
-        },
-        output_table=Table("my_table_from_file"),
-    )
-```
-
 ### Raw SQL
 
 Most ETL use cases can be addressed by cross-sharing task outputs, as shown above with `@aql.transform`. If you need to perform a SQL operation that doesn't return a table but might take a table as an argument, you can use `@aql.run_raw_sql`. 

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import warnings
 from typing import Callable, Iterable, List, Mapping, Optional, Union
 
 from astro.sql.operators.agnostic_aggregate_check import aggregate_check
@@ -63,6 +64,10 @@ def transform_file(
     warehouse: Optional[str] = None,
     output_table: Table = None,
 ):
+    warnings.warn(
+        "astro.sql.transform_file is now deprecated and will be taken out in version 1.0. Please use astro.sql.render instead"
+    )
+
     def transform_file():
         return sql
 

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import warnings
 from typing import Callable, Iterable, List, Mapping, Optional, Union
 
 from astro.sql.operators.agnostic_aggregate_check import aggregate_check
@@ -48,36 +47,6 @@ def transform(
         multiple_outputs=multiple_outputs,
         conn_id=conn_id,
         autocommit=autocommit,
-        parameters=parameters,
-        database=database,
-        schema=schema,
-        warehouse=warehouse,
-    )
-
-
-def transform_file(
-    sql=None,
-    conn_id: str = "",
-    parameters=None,
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
-    warehouse: Optional[str] = None,
-    output_table: Table = None,
-):
-    warnings.warn(
-        "astro.sql.transform_file is now deprecated and will be taken out in version 1.0. Please use astro.sql.render instead"
-    )
-
-    def transform_file():
-        return sql
-
-    return SqlDecoratoratedOperator(
-        task_id=get_task_id("transform_file", sql),
-        sql=sql,
-        python_callable=transform_file,
-        op_kwargs={"output_table": output_table},
-        op_args=(),
-        conn_id=conn_id,
         parameters=parameters,
         database=database,
         schema=schema,

--- a/tests/operators/test_postgres_decorator.py
+++ b/tests/operators/test_postgres_decorator.py
@@ -335,46 +335,6 @@ class TestPostgresDecorator(unittest.TestCase):
 
         drop_table(table_name="my_table", postgres_conn=self.hook_target.get_conn())
 
-    def test_sql_file(self):
-        self.hook_target = PostgresHook(
-            postgres_conn_id="postgres_conn", schema="pagila"
-        )
-
-        drop_table(
-            table_name="my_table_from_file", postgres_conn=self.hook_target.get_conn()
-        )
-
-        cwd = pathlib.Path(__file__).parent
-
-        with self.dag:
-            f = aql.transform_file(
-                sql=str(cwd) + "/test.sql",
-                conn_id="postgres_conn",
-                database="pagila",
-                parameters={
-                    "actor": Table("actor"),
-                    "film_actor_join": Table("film_actor"),
-                    "unsafe_parameter": "G%%",
-                },
-                output_table=Table("my_table_from_file"),
-            )
-
-        test_utils.run_dag(self.dag)
-
-        # Read table from db
-        df = pd.read_sql(
-            f"SELECT * FROM {test_utils.DEFAULT_SCHEMA}.my_table_from_file",
-            con=self.hook_target.get_conn(),
-        )
-        assert df.iloc[0].to_dict() == {
-            "actor_id": 191,
-            "first_name": "GREGORY",
-            "last_name": "GOODING",
-            "count": 30,
-        }
-
-        drop_table(table_name="my_table", postgres_conn=self.hook_target.get_conn())
-
     def test_raw_sql_result(self):
         self.hook_target = PostgresHook(
             postgres_conn_id="postgres_conn", schema="pagila"


### PR DESCRIPTION
Now that we have aql.render, the transform_file function is redundant and should be removed as part of 1.0