### PR TITLE
Allow users to customise the task name when using @df #126

### DIFF
--- a/src/astro/dataframe/__init__.py
+++ b/src/astro/dataframe/__init__.py
@@ -28,12 +28,14 @@ def dataframe(
     database: Optional[str] = None,
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
+    task_id: Optional[str] = None,
 ):
     """
     This function allows a user to run python functions in Airflow but with the huge benefit that SQL files
     will automatically be turned into dataframes and resulting dataframes can automatically used in astro.sql functions
     """
     return task_decorator_factory(
+        task_id=task_id,
         python_callable=python_callable,
         multiple_outputs=multiple_outputs,
         decorated_operator_class=SqlDataframeOperator,  # type: ignore

--- a/src/astro/dataframe/__init__.py
+++ b/src/astro/dataframe/__init__.py
@@ -34,15 +34,17 @@ def dataframe(
     This function allows a user to run python functions in Airflow but with the huge benefit that SQL files
     will automatically be turned into dataframes and resulting dataframes can automatically used in astro.sql functions
     """
+    param_map = {
+        "conn_id": conn_id,
+        "database": database,
+        "schema": schema,
+        "warehouse": warehouse,
+    }
+    if task_id:
+        param_map["task_id"] = task_id
     return task_decorator_factory(
-        task_id=task_id,
         python_callable=python_callable,
         multiple_outputs=multiple_outputs,
         decorated_operator_class=SqlDataframeOperator,  # type: ignore
-        **{
-            "conn_id": conn_id,
-            "database": database,
-            "schema": schema,
-            "warehouse": warehouse,
-        }
+        **param_map
     )


### PR DESCRIPTION
Context

As of Astro 0.5.1, if a user calls multiple times a function decorated with @df (example below), the tasks will be automatically named row_to_gcs_files__1. At the moment, the user cannot override the default task_id name when using @df.

@df
def rows_to_gcs_files()
This behavior is different from the @task decorator, which allows users to specify task_id. We should make them consistent. This works:

@task(task_id = 'load_json')
Acceptance criteria

Users are able to override the default task_id name when using the df decorator, similar to the @task decorator
Ask @mag3141592 (bug reporter) to review the PR