### PR TITLE
Add full integration test DAG

### DIFF
--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -89,7 +89,7 @@ def append(
         columns=columns,
         casted_columns=casted_columns,
         **kwargs,
-    )
+    ).output
 
 
 def merge(

--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -89,16 +89,16 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
         super().__init__(
             raw_sql=True,
             parameters={},
-            conn_id=table.conn_id,
             task_id=task_id,
             op_args=(),
             handler=handler_func,
             python_callable=null_function,
-            database=table.database,
             **kwargs,
         )
 
     def execute(self, context: Dict):
+        self.conn_id = self.table.conn_id
+        self.database = self.table.database
         self.sql = self.check
         self.parameters = {"table": self.table}
         query_result = super().execute(context)
@@ -135,6 +135,7 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
                     query_result, self.greater_than
                 )
             )
+        return self.table
 
 
 def aggregate_check(

--- a/src/astro/sql/operators/agnostic_sql_append.py
+++ b/src/astro/sql/operators/agnostic_sql_append.py
@@ -81,13 +81,17 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
             casted_columns=self.casted_columns,
             conn_id=self.main_table.conn_id,
         )
-        return super().execute(context)
+        super().execute(context)
+        return self.main_table
 
     def append(
         self, main_table: Table, columns, casted_columns, append_table: Table, conn_id
     ):
         engine = self.get_sql_alchemy_engine()
-        metadata = MetaData()
+        if self.conn_type in ["postgres", "postgresql"]:
+            metadata = MetaData(schema=self.schema)
+        else:
+            metadata = MetaData()
         # TO Do - fix bigquery and postgres reflection table issue.
         main_table_sqla = SqlaTable(
             get_table_name(main_table), metadata, autoload_with=engine

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -77,6 +77,12 @@ def tmp_table(sql_server):
 
 @pytest.fixture
 def merge_keys(sql_server):
+    """
+    To match with their respective API's, we have a slightly different "merge_keys" value
+    when a user is using snowflake.
+    :param sql_server:
+    :return:
+    """
     sql_name, _ = sql_server
 
     if sql_name == "snowflake":

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -1,0 +1,109 @@
+import pathlib
+
+import pandas as pd
+from airflow.hooks.sqlite_hook import SqliteHook
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.utils import timezone
+from airflow.utils.db import create_default_connections
+from airflow.utils.session import provide_session
+
+from astro import sql as aql
+from astro.dataframe import dataframe as adf
+from astro.sql.table import Table, TempTable
+from astro.utils.dependencies import PostgresHook, SnowflakeHook
+from tests.operators import utils as test_utils
+
+OUTPUT_TABLE_NAME = test_utils.get_table_name("integration_test_table")
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+
+CWD = pathlib.Path(__file__).parent
+import pytest
+
+
+@pytest.fixture
+def sql_server(request):
+    sql_name = request.param
+    hook_parameters = test_utils.SQL_SERVER_HOOK_PARAMETERS.get(sql_name)
+    hook_class = test_utils.SQL_SERVER_HOOK_CLASS.get(sql_name)
+    if hook_parameters is None or hook_class is None:
+        raise ValueError(f"Unsupported SQL server {sql_name}")
+    hook = hook_class(**hook_parameters)
+    schema = hook_parameters.get("schema", test_utils.DEFAULT_SCHEMA)
+    if not isinstance(hook, BigQueryHook):
+        hook.run(f"DROP TABLE IF EXISTS {schema}.{OUTPUT_TABLE_NAME}")
+    yield (sql_name, hook)
+    if not isinstance(hook, BigQueryHook):
+        hook.run(f"DROP TABLE IF EXISTS {schema}.{OUTPUT_TABLE_NAME}")
+
+
+@provide_session
+def get_session(session=None):
+    create_default_connections(session)
+    return session
+
+
+@pytest.fixture()
+def session():
+    return get_session()
+
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+    "retry_delay": 0,
+}
+
+
+@pytest.fixture
+def tmp_table(sql_server):
+    sql_name, hook = sql_server
+
+    if isinstance(hook, SnowflakeHook):
+        return TempTable(
+            conn_id=hook.snowflake_conn_id,
+            database=hook.database,
+            warehouse=hook.warehouse,
+        )
+    elif isinstance(hook, PostgresHook):
+        return TempTable(conn_id=hook.postgres_conn_id, database=hook.schema)
+    elif isinstance(hook, SqliteHook):
+        return TempTable(conn_id=hook.sqlite_conn_id, database="sqlite")
+    # elif isinstance(hook, BigQueryHook):
+    #     return TempTable(conn_id=hook.gcp_conn_id, database=)
+
+
+@aql.transform
+def do_a_thing(input_table: Table):
+    return "SELECT * FROM {{input_table}}"
+
+
+@adf
+def do_a_dataframe_thing(df: pd.DataFrame):
+    return df
+
+
+@pytest.mark.parametrize(
+    "sql_server", ["snowflake", "postgres", "bigquery", "sqlite"], indirect=True
+)
+def test_full_dag(sql_server, sample_dag, tmp_table):
+    with sample_dag:
+        output_table = tmp_table
+        loaded_table = aql.load_file(
+            str(CWD) + "/data/homes.csv", output_table=output_table
+        )
+        tranformed_table = do_a_thing(loaded_table)
+        dataframe_from_table = do_a_dataframe_thing(
+            tranformed_table, output_table=output_table
+        )
+        validated_table = aql.aggregate_check(
+            dataframe_from_table,
+            check="select count(*) FROM {{table}}",
+            equal_to=47,
+        )
+        aql.save_file(
+            input=validated_table.output,
+            output_file_path="/tmp/out.csv",
+            overwrite=True,
+        )
+    test_utils.run_dag(sample_dag)

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -173,9 +173,9 @@ def run_merge(output_specs: TempTable):
 @pytest.mark.parametrize(
     "sql_server",
     [
-        # "snowflake",
+        "snowflake",
         "postgres",
-        # pytest.param("bigquery", marks=pytest.mark.xfail(reason="some bug")),
+        pytest.param("bigquery", marks=pytest.mark.xfail(reason="some bug")),
         "sqlite",
     ],
     indirect=True,

--- a/tests/operators/test_postgres_append.py
+++ b/tests/operators/test_postgres_append.py
@@ -259,7 +259,7 @@ class TestPostgresAppend(unittest.TestCase):
             )
         test_utils.run_dag(self.dag)
         df = pd.read_sql(
-            f"SELECT * FROM {load_main.operator.output_table.schema}.{load_main.operator.output_table.qualified_name()}",
+            f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
             con=hook.get_conn(),
         )
 

--- a/tests/operators/test_sqlite_append.py
+++ b/tests/operators/test_sqlite_append.py
@@ -46,6 +46,7 @@ from google.cloud import bigquery
 # Import Operator
 import astro.sql as aql
 from astro.sql.table import Table
+from tests.operators import utils as test_utils
 
 # from tests.operators import utils as test_utils
 
@@ -146,22 +147,10 @@ class TestSQLiteAppend(unittest.TestCase):
             )
             foo = aql.append(
                 columns=["sell", "living"],
-                main_table=self.main_table,
-                append_table=self.append_table,
+                main_table=load_main,
+                append_table=load_append,
             )
-        dr = self.dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
-            start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-
-        load_main.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        load_append.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, load_main.operator.task_id)
-        self.wait_for_task_finish(dr, load_append.operator.task_id)
-        foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, foo.task_id)
+        test_utils.run_dag(self.dag)
 
         df = pd.read_sql(
             f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
@@ -190,22 +179,11 @@ class TestSQLiteAppend(unittest.TestCase):
                 path=str(cwd) + "/../data/homes_append.csv",
                 output_table=self.append_table,
             )
-            foo = aql.append(main_table=self.main_table, append_table=self.append_table)
-        dr = self.dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
-            start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-
-        main_table = load_main.operator.run(
-            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE
-        )
-        load_append.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, load_main.operator.task_id)
-        self.wait_for_task_finish(dr, load_append.operator.task_id)
-        foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, foo.task_id)
+            foo = aql.append(
+                main_table=load_main,
+                append_table=load_append,
+            )
+        test_utils.run_dag(self.dag)
         df = pd.read_sql(
             f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
             con=hook.get_conn(),
@@ -235,22 +213,10 @@ class TestSQLiteAppend(unittest.TestCase):
             foo = aql.append(
                 columns=["sell", "living"],
                 casted_columns={"age": "INTEGER"},
-                main_table=self.main_table,
-                append_table=self.append_table,
+                main_table=load_main,
+                append_table=load_append,
             )
-        dr = self.dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
-            start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-
-        load_main.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        load_append.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, load_main.operator.task_id)
-        self.wait_for_task_finish(dr, load_append.operator.task_id)
-        foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, foo.task_id)
+        test_utils.run_dag(self.dag)
         df = pd.read_sql(
             f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",
             con=hook.get_conn(),
@@ -281,22 +247,10 @@ class TestSQLiteAppend(unittest.TestCase):
             )
             foo = aql.append(
                 casted_columns={"age": "INTEGER"},
-                main_table=self.main_table,
-                append_table=self.append_table,
+                main_table=load_main,
+                append_table=load_append,
             )
-        dr = self.dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
-            start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-
-        load_main.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        load_append.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, load_main.operator.task_id)
-        self.wait_for_task_finish(dr, load_append.operator.task_id)
-        foo.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        self.wait_for_task_finish(dr, foo.task_id)
+        test_utils.run_dag(self.dag)
 
         df = pd.read_sql(
             f"SELECT * FROM {load_main.operator.output_table.qualified_name()}",


### PR DESCRIPTION
To ensure full feature parity between data systems, we should develop integration DAGs that test all known scenarios, this is beyond just example DAGs as the DAGs will make it easy to switch databases by changing the input table params.