### PR TITLE
Use standard AWS Env Variables

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -8,5 +8,6 @@ SNOWFLAKE_REGION=<add snowflake region here>
 SNOWFLAKE_ROLE=<add snowflake role here>
 SNOWFLAKE_DATABASE=<add snowflake database here>
 SNOWFLAKE_WAREHOUSE=<add snowflake warehouse here>
-AIRFLOW__ASTRO__CONN_AWS_DEFAULT=<add aws api key here>:<add aws secret key here>@
+AWS_ACCESS_KEY_ID=<add aws api key here>
+AWS_SECRET_ACCESS_KEY=<add aws secret key here>
 AIRFLOW_VAR_FOO=templated_file_name

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,8 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
-      AIRFLOW__ASTRO__CONN_AWS_DEFAULT: ${{ secrets.AWS_ACCESS_CRED }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AIRFLOW__ASTRO__SQL_SCHEMA: astroflow_ci
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
@@ -107,7 +108,8 @@ jobs:
       GOOGLE_BUCKET: dag-authoring
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
-      AIRFLOW__ASTRO__CONN_AWS_DEFAULT: ${{ secrets.AWS_ACCESS_CRED }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AIRFLOW__ASTRO__SQL_SCHEMA: astroflow_ci
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}

--- a/docs/OLD_README.md
+++ b/docs/OLD_README.md
@@ -401,7 +401,7 @@ with dag:
 ## Loading Data
 
 To create an ELT pipeline, users can first load CSV or parquet data from either local, S3, or GCS into a SQL database with the `load_sql` function. 
-To interact with S3, you must set an S3 Airflow connection in the `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` environment variable.
+To interact with S3, you must set an S3 Airflow connection in the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`  environment variables.
 
 In the following example, we load data from S3 by specifying the path and connection ID for our S3 database in `aql.load_file`: 
 

--- a/src/astro/utils/cloud_storage_creds.py
+++ b/src/astro/utils/cloud_storage_creds.py
@@ -14,14 +14,7 @@ from astro.utils.dependencies import (
 
 
 def parse_s3_env_var():
-    raw_data = (
-        os.environ["AIRFLOW__ASTRO__CONN_AWS_DEFAULT"]
-        .replace("%2F", "/")
-        .replace("aws://", "")
-        .replace("@", "")
-        .split(":")
-    )
-    return [parse.unquote(r) for r in raw_data]
+    return os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
 
 
 def s3fs_creds(conn_id=None):

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -479,10 +479,7 @@ class TestAgnosticLoadFile(unittest.TestCase):
 
 @mock.patch.dict(
     os.environ,
-    {
-        "AWS_ACCESS_KEY_ID": "abcd", 
-        "AWS_SECRET_ACCESS_KEY": "@#$%@$#ASDH@Ksd23%SD546"
-    },
+    {"AWS_ACCESS_KEY_ID": "abcd", "AWS_SECRET_ACCESS_KEY": "@#$%@$#ASDH@Ksd23%SD546"},
 )
 def test_aws_decode():
     from astro.utils.cloud_storage_creds import parse_s3_env_var

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -19,7 +19,8 @@ Unittest module to test Agnostic Load File function.
 Requires the unittest, pytest, and requests-mock Python libraries.
 
 Run test:
-    AIRFLOW__ASTRO__CONN_AWS_DEFAULT=aws://AKIAZG42HVH6Z3B6ELRB:SgwfrcO2NdKpeKhUG77K%2F6B2HuRJJopbHPV84NbY@ \
+    AWS_ACCESS_KEY_ID=AKIAZG42HVH6Z3B6ELRB \
+    AWS_SECRET_ACCESS_KEY=SgwfrcO2NdKpeKhUG77K%2F6B2HuRJJopbHPV84NbY \
     python3 -m unittest tests.operators.test_agnostic_load_file.TestAgnosticLoadFile.test_aql_local_file_to_postgres
 
 """
@@ -479,7 +480,8 @@ class TestAgnosticLoadFile(unittest.TestCase):
 @mock.patch.dict(
     os.environ,
     {
-        "AIRFLOW__ASTRO__CONN_AWS_DEFAULT": "abcd:%40%23%24%25%40%24%23ASDH%40Ksd23%25SD546@"
+        "AWS_ACCESS_KEY_ID": "abcd", 
+        "AWS_SECRET_ACCESS_KEY": "@#$%@$#ASDH@Ksd23%SD546"
     },
 )
 def test_aws_decode():

--- a/tests/operators/test_agnostic_save_file.py
+++ b/tests/operators/test_agnostic_save_file.py
@@ -364,7 +364,10 @@ class TestSaveFile(unittest.TestCase):
         """
         # To-do: clean-up how S3 creds are passed to s3fs
 
-        return {"key": os.environ["AWS_ACCESS_KEY_ID"], "secret":  os.environ["AWS_SECRET_ACCESS_KEY"]}
+        return {
+            "key": os.environ["AWS_ACCESS_KEY_ID"],
+            "secret": os.environ["AWS_SECRET_ACCESS_KEY"],
+        }
 
 
 @pytest.fixture

--- a/tests/operators/test_agnostic_save_file.py
+++ b/tests/operators/test_agnostic_save_file.py
@@ -19,7 +19,8 @@ Unittest module to test Agnostic Load File function.
 Requires the unittest, pytest, and requests-mock Python libraries.
 
 Run test:
-    AIRFLOW__ASTRO__CONN_AWS_DEFAULT=aws://KEY:SECRET@
+    AWS_ACCESS_KEY_ID=KEY \
+    AWS_SECRET_ACCESS_KEY=SECRET \
     python3 -m unittest tests.operators.test_save_file.TestSaveFile.test_save_postgres_table_to_local
 
 """
@@ -362,15 +363,8 @@ class TestSaveFile(unittest.TestCase):
         s3fs enables pandas to write to s3
         """
         # To-do: clean-up how S3 creds are passed to s3fs
-        k, v = (
-            os.environ["AIRFLOW__ASTRO__CONN_AWS_DEFAULT"]
-            .replace("%2F", "/")
-            .replace("aws://", "")
-            .replace("@", "")
-            .split(":")
-        )
 
-        return {"key": k, "secret": v}
+        return {"key": os.environ["AWS_ACCESS_KEY_ID"], "secret":  os.environ["AWS_SECRET_ACCESS_KEY"]}
 
 
 @pytest.fixture

--- a/tests/operators/test_postgres_append.py
+++ b/tests/operators/test_postgres_append.py
@@ -20,7 +20,8 @@ Unittest module to test Operators.
 Requires the unittest, pytest, and requests-mock Python libraries.
 
 Run test:
-    AIRFLOW__ASTRO__CONN_AWS_DEFAULT=aws://KEY:SECRET@ \
+    AWS_ACCESS_KEY_ID=KEY \
+    AWS_SECRET_ACCESS_KEY=SECRET \
     python3 -m unittest tests.operators.test_postgres_operator.TestPostgresOperator.test_load_s3_to_sql_db
 
 """

--- a/tests/operators/test_sqlite_append.py
+++ b/tests/operators/test_sqlite_append.py
@@ -20,7 +20,8 @@ Unittest module to test Operators.
 Requires the unittest, pytest, and requests-mock Python libraries.
 
 Run test:
-    AIRFLOW__ASTRO__CONN_AWS_DEFAULT=aws://KEY:SECRET@ \
+    AWS_ACCESS_KEY_ID=KEY \
+    AWS_SECRET_ACCESS_KEY=SECRET \
     python3 -m unittest tests.operators.test_postgres_operator.TestPostgresOperator.test_load_s3_to_sql_db
 
 """


### PR DESCRIPTION
Fix #175  

- The PR replaces `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` to AWS standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
- The `parse_s3_env_var` will return the set environment variables
