### PR TITLE
Fixed bigquery merge op.

### DIFF
--- a/src/astro/utils/bigquery_merge_func.py
+++ b/src/astro/utils/bigquery_merge_func.py
@@ -29,7 +29,7 @@ def bigquery_merge_func(
                 WHEN NOT MATCHED BY TARGET THEN INSERT ({','.join(target_columns)}) VALUES ({','.join(merge_columns)})"
 
     if conflict_strategy == "update":
-        update_statement = f"UPDATE SET {', '.join(['T.' + col + '=S.' + col for col in target_columns])}"
+        update_statement = f"UPDATE SET {', '.join(['T.' + target_columns[index] + '=S.' + merge_columns[index] for index in range(len(target_columns))])}"
         statement += f" WHEN MATCHED THEN {update_statement}"
 
     return statement, {}

--- a/tests/operators/test_agnostic_merge.py
+++ b/tests/operators/test_agnostic_merge.py
@@ -107,7 +107,10 @@ def validate_results(df: pd.DataFrame, mode, sql_type):
         df = df.iloc[::-1]
 
     def set_compare(l1, l2):
+        l1 = list(filter(lambda val: not math.isnan(val), l1))
         return set(l1) == set(l2)
+
+    df = df.sort_values(by=["list"], ascending=True)
 
     if mode == "single":
         assert set_compare(df.age.to_list()[:-1], [60.0, 12.0, 41.0, 22.0])
@@ -151,14 +154,9 @@ def run_merge(output_specs: TempTable, merge_parameters, mode, sql_type):
 @pytest.mark.parametrize(
     "sql_server",
     [
+        "bigquery",
         "snowflake",
         "postgres",
-        pytest.param(
-            "bigquery",
-            marks=pytest.mark.xfail(
-                reason="There is a known issue preventing update in bigquery"
-            ),
-        ),
         "sqlite",
     ],
     indirect=True,


### PR DESCRIPTION
Fixes - 
1. There was wrong mapping of target_columns to merge_columns, rectified it.
2. When we recreate dataframe post merging there is no order of rows specified for biquery, to generalize results, sorted returned rows by 'list' col and filtered 'nan' values.
Example - 
```
table 1:
row 1
row 2

table 2:
row 3
row 4

Merged table:
row 3
row 4
row 1
row 2

OR 

row 3
row 1
row 4
row 2
```