### PR TITLE
Add codecov coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,12 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s test -- --splits 8 --group ${{ matrix.group }}
+      - run: nox -s test -- --splits 8 --group ${{ matrix.group }} --cov=./ --cov-report=xml --cov-branch
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
     env:
       AWS_BUCKET: tmp9
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .git
+coverage.xml
 .env
+.coverage
 integration-tests/test_data*
 astronomer_sql_decorator.egg-info
 test-connections.yaml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Contributors](https://img.shields.io/github/contributors/astro-projects/astro)](https://github.com/astro-projects/astro)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/astro-projects/astro)](https://github.com/astro-projects/astro)
 [![CI](https://github.com/astro-projects/astro/actions/workflows/ci.yaml/badge.svg)](https://github.com/astro-projects/astro)
+[![codecov](https://codecov.io/gh/astro-projects/astro/branch/main/graph/badge.svg?token=MI4SSE50Q6)](https://codecov.io/gh/astro-projects/astro)
 
 **astro** allows rapid and clean development of {Extract, Load, Transform} workflows using Python.
 It helps DAG authors to achieve more with less code. 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,6 +78,44 @@ On only 3.9 (for example):
 Please also note that you can reuse an existing environtment if you run nox with the `-r` argument (or even `-R` if you
 don't want to attempt to reinstall packages). This can significantly speed up repeat test runs.
 
+## Check code coverage
+
+To run code coverage locally, you can either use `pytest` in one of the test environments or
+run `nox -s test` with coverage arguments. We use [pytest-cov](https://pypi.org/project/pytest-cov/) for our coverage reporting.
+
+Below is an example of running a coverage report on a single test. In this case the relevent file is `src/astro/sql/operators/sql_decorator.py`
+since we are testing the postgres `transform` decorator.
+
+```shell script
+nox -R -s test -- --cov-report term --cov=src/astro/sql/operators  tests/operators/test_postgres_decorator.py
+===================================================== test session starts =====================================================
+platform darwin -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
+rootdir: /Users/dimberman/code/astronomer/astro-project/plugins/astro, configfile: pyproject.toml
+plugins: anyio-3.5.0, requests-mock-1.9.3, split-0.6.0, dotenv-0.5.2, cov-3.0.0
+collected 12 items
+
+tests/operators/test_postgres_decorator.py ............                                                                 [100%]
+
+====================================================== warnings summary =======================================================
+
+---------- coverage: platform darwin, python 3.9.10-final-0 ----------
+Name                                                  Stmts   Miss Branch BrPart  Cover   Missing
+-------------------------------------------------------------------------------------------------
+src/astro/sql/operators/__init__.py                       0      0      0      0   100%
+src/astro/sql/operators/agnostic_aggregate_check.py      46     32     16      0    26%   61-89, 100-138, 162
+src/astro/sql/operators/agnostic_boolean_check.py        66     45     16      0    30%   19-21, 24, 27, 51-65, 80-95, 98-105, 109, 115-128, 131, 149
+src/astro/sql/operators/agnostic_load_file.py            56     35     10      0    35%   61-67, 76-101, 106-110, 118-140, 166-167
+src/astro/sql/operators/agnostic_save_file.py            65     43     14      0    30%   64-70, 79-95, 98-109, 112-152, 162-182, 188-190, 220-224
+src/astro/sql/operators/agnostic_sql_append.py           50     36     20      0    23%   45-56, 67-85, 90-117
+src/astro/sql/operators/agnostic_sql_merge.py            43     28     12      0    31%   48-59, 69-118
+src/astro/sql/operators/agnostic_sql_truncate.py         20     11      2      0    50%   32-40, 55-60
+src/astro/sql/operators/agnostic_stats_check.py         110     86     32      0    21%   24-27, 32-33, 36-49, 52-73, 76-92, 95-98, 103-119, 122, 125-134, 146-169, 196-216, 231-260, 280
+src/astro/sql/operators/sql_dataframe.py                 76     13     22      2    79%   83, 130, 160-174
+src/astro/sql/operators/sql_decorator.py                201     45     78     16    72%   107-110, 126->128, 137, 166, 175, 194-196, 206->210, 223-224, 228-243, 247-248, 259, 277, 280, 287, 291-293, 296, 311, 315, 322-327, 330-335, 340, 346-363, 380-392
+-------------------------------------------------------------------------------------------------
+TOTAL                                                   733    374    222     18    46%
+```
+
 ## Release a new version
 
 <!-- Not yet verified. -->

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,7 +87,7 @@ Below is an example of running a coverage report on a single test. In this case 
 since we are testing the postgres `transform` decorator.
 
 ```shell script
-nox -R -s test -- --cov-report term --cov=src/astro/sql/operators  tests/operators/test_postgres_decorator.py
+nox -R -s test -- --cov-report term --cov-branch --cov=src/astro/sql/operators  tests/operators/test_postgres_decorator.py
 ===================================================== test session starts =====================================================
 platform darwin -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
 rootdir: /Users/dimberman/code/astronomer/astro-project/plugins/astro, configfile: pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ dependencies = [
     "pandas>=1.3.4,<=1.3.5",
     "SQLAlchemy>=1.3.18,<=1.3.24",
     "markupsafe>=1.1.1,<2.1.0",
-    "smart-open",
-    "coverage"
+    "smart-open"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "pandas>=1.3.4,<=1.3.5",
     "SQLAlchemy>=1.3.18,<=1.3.24",
     "markupsafe>=1.1.1,<2.1.0",
-    "smart-open"
+    "smart-open",
+    "coverage"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]
@@ -43,6 +44,7 @@ tests = [
     "pytest-split",
     "pytest-dotenv",
     "requests-mock",
+    "pytest-cov",
 ]
 google = [
     "apache-airflow-providers-google",


### PR DESCRIPTION
Description

To improve the testing health of the project, we will add a [codecov](https://about.codecov.io/) integration s.t. all PRs with passing tests will recieve a codecov report. We will also fail any PR where code coverage goes down more than 2%.

Acceptance criteria

- [x]  Users should have the ability to locally run a code coverage plugin to get reports without submitting to CI
- [x] CI should automatically generate a code coverage report when users submit a PR with passing tests
- [x] As part of the pull request, evaluate the coverage and fail if the coverage goes down by more than -2%
- [x] Enable [code-cov](https://about.codecov.io/) on the Github repo

Resolves  #191 