### PR TITLE
Codecov should ignore test files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ coverage:
       default:
         target: auto
         threshold: 2%
+ignore:
+  - "test_*.py"


### PR DESCRIPTION
We shouldn't need to run coverage on test files, otherwise our CI will break because our test files are not properly tested.