### PR TITLE
Fix running tests in parallel

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 import pytest
 import yaml
@@ -33,9 +34,15 @@ def create_database_connections():
             session.add(conn)
 
 
+def _create_unique_dag_id():
+    unique_id = str(uuid.uuid4()).replace("-", "")
+    return f"test_dag_{unique_id}"
+
+
 @pytest.fixture
 def sample_dag():
-    yield DAG("test_dag", default_args={"owner": "airflow", "start_date": DEFAULT_DATE})
+    dag_id = _create_unique_dag_id()
+    yield DAG(dag_id, default_args={"owner": "airflow", "start_date": DEFAULT_DATE})
     with create_session() as session:
         session.query(DagRun).delete()
         session.query(TI).delete()

--- a/conftest.py
+++ b/conftest.py
@@ -79,13 +79,9 @@ def tmp_table(sql_server):
     elif isinstance(hook, SnowflakeHook):
         hook.run(f"DROP TABLE IF EXISTS {temporary_table.table_name}")
     elif not isinstance(hook, BigQueryHook):
-        hook.run(
-            f"ALTER TABLE {temporary_table.schema}.{temporary_table.table_name} DROP CONSTRAINT IF EXISTS airflow;"
-        )
-        hook.run(
-            f"DROP TABLE IF EXISTS {temporary_table.schema}.{temporary_table.table_name}"
-        )
-        hook.run(f"DROP INDEX IF EXISTS unique_index")
+        # There are some tests (e.g. test_agnostic_merge.py) which create stuff which are not being deleted
+        # Example: tables which are not fixtures and constraints. This is an agressive approach towards tearing down:
+        hook.run(f"DROP SCHEMA IF EXISTS {temporary_table.schema} CASCADE;")
 
 
 @pytest.fixture

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -70,11 +70,17 @@ class Table:
 
 class TempTable(Table):
     def __init__(self, conn_id=None, database=None, warehouse=""):
+        self.table_name = ""
         super().__init__(
-            table_name="", conn_id=conn_id, database=database, warehouse=warehouse
+            table_name=self.table_name,
+            conn_id=conn_id,
+            database=database,
+            warehouse=warehouse,
         )
 
     def to_table(self, table_name: str, schema: str) -> Table:
+        self.table_name = table_name
+        self.schema = schema
         return Table(
             table_name=table_name,
             conn_id=self.conn_id,

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -16,6 +16,8 @@ limitations under the License.
 from airflow.hooks.base import BaseHook
 from airflow.models import DagRun, TaskInstance
 
+MAX_TABLE_NAME_SIZE = 63
+
 
 class Table:
     template_fields = (
@@ -87,7 +89,7 @@ def create_table_name(context) -> str:
     dag_run: DagRun = ti.get_dagrun()
     table_name = f"{dag_run.dag_id}_{ti.task_id}_{dag_run.id}".replace(
         "-", "_"
-    ).replace(".", "__")
+    ).replace(".", "__")[:MAX_TABLE_NAME_SIZE]
     if not table_name.isidentifier():
         table_name = f'"{table_name}"'
     return table_name

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -669,4 +669,5 @@ def test_load_file_chunks(sample_dag, sql_server):
         task_params = create_task_parameters(database_name, file_type)
         test_utils.create_and_run_task(sample_dag, load_file, (), task_params)
 
-    assert mock_chunk_function.call_args_list[0].kwargs[chunk_size_argument] == 1000000
+    _, kwargs = mock_chunk_function.call_args
+    assert kwargs[chunk_size_argument] == 1000000


### PR DESCRIPTION
Fix #208 by giving unique dag_ids for test DAGs

Acceptance criteria
* [x] Make the tests more reliable, by avoiding table name clashes.