### PR TITLE
Refactored Load_file Op. testcases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tests/benchmark/logs/*
 tests/benchmark/webserver_config.py
 *.sw[a-z]
 docs/sphinx/_build/*
+.DS_Store
+*/.DS_Store

--- a/conftest.py
+++ b/conftest.py
@@ -65,11 +65,11 @@ def sample_dag():
 
 @pytest.fixture
 def test_table(request, sql_server):
-    table_type = True
+    is_tmp_table = True
     table_options = {}
 
     if getattr(request, "param", None):
-        table_type = request.param.get("is_temp", True)
+        is_tmp_table = request.param.get("is_temp", True)
         table_options = request.param.get("param", {})
     sql_name, hook = sql_server
 
@@ -91,7 +91,7 @@ def test_table(request, sql_server):
         raise ValueError("Unsupported Database")
 
     params.update(table_options)
-    table = TempTable(**params) if table_type else Table(**params)
+    table = TempTable(**params) if is_tmp_table else Table(**params)
 
     yield table
 

--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ def sample_dag():
 
 
 @pytest.fixture
-def tmp_table(request, sql_server):
+def test_table(request, sql_server):
     table_type = True
     table_options = {}
 

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -162,9 +162,9 @@ def run_merge(output_specs: TempTable, merge_keys):
     ],
     indirect=True,
 )
-def test_full_dag(sql_server, sample_dag, tmp_table):
+def test_full_dag(sql_server, sample_dag, test_table):
     with sample_dag:
-        output_table = tmp_table
+        output_table = test_table
         loaded_table = aql.load_file(
             str(CWD) + "/data/homes.csv", output_table=output_table
         )

--- a/tests/operators/test_agnostic_append.py
+++ b/tests/operators/test_agnostic_append.py
@@ -65,17 +65,17 @@ def append_params(request):
     ],
     indirect=True,
 )
-def test_append(sql_server, sample_dag, tmp_table, append_params):
+def test_append(sql_server, sample_dag, test_table, append_params):
     app_param, validate_append = append_params
 
     with sample_dag:
         load_main = aql.load_file(
             path=str(CWD) + "/../data/homes_main.csv",
-            output_table=tmp_table,
+            output_table=test_table,
         )
         load_append = aql.load_file(
             path=str(CWD) + "/../data/homes_append.csv",
-            output_table=tmp_table,
+            output_table=test_table,
         )
         appended_table = aql.append(
             **app_param,
@@ -97,17 +97,17 @@ from astro.sql.table import TempTable
     indirect=True,
 )
 def test_append_on_tables_on_different_db(sample_dag, sql_server):
-    tmp_table_1 = TempTable(conn_id="postgres_conn")
-    tmp_table_2 = TempTable(conn_id="sqlite_conn")
+    test_table_1 = TempTable(conn_id="postgres_conn")
+    test_table_2 = TempTable(conn_id="sqlite_conn")
     with pytest.raises(BackfillUnfinished):
         with sample_dag:
             load_main = aql.load_file(
                 path=str(CWD) + "/../data/homes_main.csv",
-                output_table=tmp_table_1,
+                output_table=test_table_1,
             )
             load_append = aql.load_file(
                 path=str(CWD) + "/../data/homes_append.csv",
-                output_table=tmp_table_2,
+                output_table=test_table_2,
             )
             appended_table = aql.append(
                 main_table=load_main,

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -100,7 +100,7 @@ def test_load_file_with_http_path_file(sample_dag, tmp_table, sql_server):
     indirect=True,
     ids=["temp_table", "named_table"],
 )
-def test_aql_s3_file_to_postgres(sample_dag, tmp_table, sql_server, remote_file):
+def test_aql_load_remote_file_to_dbs(sample_dag, tmp_table, sql_server, remote_file):
     sql_name, hook = sql_server
     file_conn_id, file_uri = remote_file
 

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -14,6 +14,7 @@ import logging
 import os
 import pathlib
 import unittest.mock
+from typing import Union
 from unittest import mock
 
 import pandas as pd
@@ -44,7 +45,7 @@ OUTPUT_SCHEMA = os.getenv("SNOWFLAKE_SCHEMA")
 CWD = pathlib.Path(__file__).parent
 
 
-def get_dataframe_from_table(sql_name: str, test_table: Table, hook):
+def get_dataframe_from_table(sql_name: str, test_table: Union[Table, TempTable], hook):
     if sql_name == "bigquery":
         client = bigquery.Client()
         query_job = client.query(

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -113,7 +113,7 @@ def test_aql_s3_file_to_postgres(sample_dag, tmp_table, sql_server, remote_file)
     # Workaround for snowflake capitalized col names
     sort_cols = "name"
     if sort_cols not in df.columns:
-        sort_cols.upper()
+        sort_cols = sort_cols.upper()
 
     df = df.sort_values(by=[sort_cols])
 

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -109,7 +109,13 @@ def test_aql_s3_file_to_postgres(sample_dag, tmp_table, sql_server, remote_file)
     test_utils.run_dag(sample_dag)
 
     df = get_dataframe_from_table(sql_name, tmp_table, hook)
-    df = df.sort_values(by=["name"])
+
+    # Workaround for snowflake capitalized col names
+    sort_cols = "name"
+    if sort_cols not in df.columns:
+        sort_cols.upper()
+
+    df = df.sort_values(by=[sort_cols])
 
     assert df.iloc[0].to_dict()["name"] == "First"
 

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -117,7 +117,7 @@ def test_aql_load_remote_file_to_dbs(sample_dag, tmp_table, sql_server, remote_f
 
     df = df.sort_values(by=[sort_cols])
 
-    assert df.iloc[0].to_dict()["name"] == "First"
+    assert df.iloc[0].to_dict()[sort_cols] == "First"
 
 
 @pytest.mark.integration

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -394,7 +394,7 @@ def test_load_file(sample_dag, sql_server, file_type):
 
 
 @pytest.mark.parametrize(
-    "sql_server", ["bigquery", "postgres", "snowflake"], indirect=True
+    "sql_server", ["bigquery", "postgres", "snowflake", "sqlite"], indirect=True
 )
 def test_load_file_chunks(sample_dag, sql_server):
     file_type = "csv"

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -63,6 +63,12 @@ def get_dataframe_from_table(sql_name: str, tmp_table: Table, hook):
 @pytest.mark.parametrize(
     "sql_server", ["snowflake", "postgres", "bigquery", "sqlite"], indirect=True
 )
+@pytest.mark.parametrize(
+    "tmp_table",
+    [{"is_temp": True}, {"is_temp": False}],
+    indirect=True,
+    ids=["temp_table", "named_table"],
+)
 def test_aql_http_path_file_to_postgres(sample_dag, tmp_table, sql_server):
     sql_name, hook = sql_server
 
@@ -88,6 +94,12 @@ def test_aql_http_path_file_to_postgres(sample_dag, tmp_table, sql_server):
 @pytest.mark.parametrize(
     "sql_server", ["snowflake", "postgres", "bigquery", "sqlite"], indirect=True
 )
+@pytest.mark.parametrize(
+    "tmp_table",
+    [{"is_temp": True}, {"is_temp": False}],
+    indirect=True,
+    ids=["temp_table", "named_table"],
+)
 def test_aql_s3_file_to_postgres(sample_dag, tmp_table, sql_server, remote_file):
     sql_name, hook = sql_server
     file_conn_id, file_uri = remote_file
@@ -105,6 +117,12 @@ def test_aql_s3_file_to_postgres(sample_dag, tmp_table, sql_server, remote_file)
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "sql_server", ["snowflake", "postgres", "bigquery", "sqlite"], indirect=True
+)
+@pytest.mark.parametrize(
+    "tmp_table",
+    [{"is_temp": True}, {"is_temp": False}],
+    indirect=True,
+    ids=["temp_table", "named_table"],
 )
 def test_aql_replace_existing_table(sample_dag, tmp_table, sql_server):
     sql_name, hook = sql_server
@@ -125,6 +143,12 @@ def test_aql_replace_existing_table(sample_dag, tmp_table, sql_server):
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "sql_server", ["snowflake", "postgres", "bigquery", "sqlite"], indirect=True
+)
+@pytest.mark.parametrize(
+    "tmp_table",
+    [{"is_temp": True}, {"is_temp": False}],
+    indirect=True,
+    ids=["temp_table", "named_table"],
 )
 def test_aql_local_file_with_no_table_name(sample_dag, tmp_table, sql_server):
     sql_name, hook = sql_server

--- a/tests/operators/test_agnostic_merge.py
+++ b/tests/operators/test_agnostic_merge.py
@@ -171,10 +171,10 @@ def run_merge(output_specs: TempTable, merge_parameters, mode, sql_type):
     ],
     indirect=True,
 )
-def test_merge(sql_server, sample_dag, tmp_table, merge_parameters):
+def test_merge(sql_server, sample_dag, test_table, merge_parameters):
     sql_type, _ = sql_server
     merge_params, mode = merge_parameters
     with sample_dag:
-        output_table = tmp_table
+        output_table = test_table
         run_merge(output_table, merge_params, mode, sql_type)
     test_utils.run_dag(sample_dag)

--- a/tests/operators/transform/test_postgres_transform.py
+++ b/tests/operators/transform/test_postgres_transform.py
@@ -124,7 +124,7 @@ def test_postgres(sample_dag, pg_query_result):
 
 
 @pytest.mark.parametrize("sql_server", ["postgres"], indirect=True)
-def test_postgres_join(sample_dag, tmp_table, sql_server):
+def test_postgres_join(sample_dag, test_table, sql_server):
     @aql.transform(conn_id="postgres_conn", database="pagila")
     def sample_pg(actor: Table, film_actor_join: Table, unsafe_parameter):
         return (
@@ -147,7 +147,7 @@ def test_postgres_join(sample_dag, tmp_table, sql_server):
             actor=Table(table_name="actor", conn_id="postgres_conn", database="pagila"),
             film_actor_join=Table(table_name="film_actor"),
             unsafe_parameter="G%%",
-            output_table=tmp_table,
+            output_table=test_table,
         )
         validate(ret)
 

--- a/tests/operators/transform/test_snowflake_transform.py
+++ b/tests/operators/transform/test_snowflake_transform.py
@@ -110,13 +110,13 @@ def run_role_query(dag, table, role):
 
 
 @pytest.mark.parametrize("sql_server", ["snowflake"], indirect=True)
-def test_roles_failing(sql_server, sample_dag, tmp_table):
-    tmp_table.role = "foo"
+def test_roles_failing(sql_server, sample_dag, test_table):
+    test_table.role = "foo"
     with pytest.raises(Exception):
-        run_role_query(sample_dag, tmp_table, role="foo")
+        run_role_query(sample_dag, test_table, role="foo")
 
 
 @pytest.mark.parametrize("sql_server", ["snowflake"], indirect=True)
-def test_roles_passing(sql_server, sample_dag, tmp_table):
-    tmp_table.role = os.getenv("SNOWFLAKE_ROLE")
-    run_role_query(sample_dag, tmp_table, role=os.getenv("SNOWFLAKE_ROLE"))
+def test_roles_passing(sql_server, sample_dag, test_table):
+    test_table.role = os.getenv("SNOWFLAKE_ROLE")
+    run_role_query(sample_dag, test_table, role=os.getenv("SNOWFLAKE_ROLE"))


### PR DESCRIPTION
Closes: #194 

- [x] Each test should work across all databases
- [x] Use test_utils.run_dag
- [x] Use PyTest fixtures and parameterize to have a single main test that will validate transform across multiple databases
- [x] Loading against all formats (csv, parquet, avro, etc.)  -- **Partially done, since it's not required for all tests.**
- [x] Loading to a temp_table or named table -- **Partially done, since it's not required for all tests.**
- [x] Loading to default schema and to named schema -- **Partially done, since it's not required for all tests.**

