### PR TITLE
#125 added parameters to example

### DIFF
--- a/example_dags/demo_parse_directory/homes_example/clean_homes.sql
+++ b/example_dags/demo_parse_directory/homes_example/clean_homes.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM {{combine_homes}}
-WHERE ROOMS > 0
-AND ROOMS < 50
+WHERE ROOMS > {{ params['min_rooms']}}
+AND ROOMS <  {{ params['max_rooms']}}

--- a/example_dags/demo_parse_directory/homes_example/clean_homes.sql
+++ b/example_dags/demo_parse_directory/homes_example/clean_homes.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM {{combine_homes}}
-WHERE ROOMS > {{ params['min_rooms']}}
-AND ROOMS <  {{ params['max_rooms']}}
+WHERE ROOMS > {{ params.min_rooms }}
+AND ROOMS <  {{ params.max_rooms }}

--- a/example_dags/example_snowflake_render.py
+++ b/example_dags/example_snowflake_render.py
@@ -31,8 +31,8 @@ dag = DAG(
     schedule_interval="@daily",
     catchup=False,
     params={
-        "min_rooms": 0,
-        "max_rooms": 50,
+        "min_rooms": Param(0, type="integer"),
+        "max_rooms": Param(50, type="integer"),
     },
 )
 

--- a/example_dags/example_snowflake_render.py
+++ b/example_dags/example_snowflake_render.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 from airflow.decorators import dag
+from airflow.models import DAG, Param
 
 from astro.sql import load_file, render
 from astro.sql.table import Table
@@ -24,9 +25,19 @@ connection info.
 """
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
+dag = DAG(
+    dag_id="example_snowflake_render",
+    start_date=datetime(2022, 2, 1),
+    schedule_interval="@daily",
+    catchup=False,
+    params={
+        "min_rooms": 0,
+        "max_rooms": 50,
+    },
+)
 
-@dag(start_date=datetime(2022, 2, 1), schedule_interval="@daily", catchup=False)
-def example_snowflake_render():
+
+with dag:
     homes_data1 = load_file(
         path=FILE_PATH + "homes.csv",
         output_table=Table(
@@ -52,6 +63,3 @@ def example_snowflake_render():
         homes=homes_data1,
         homes2=homes_data2,
     )
-
-
-example_snowflake_render_dag = example_snowflake_render()

--- a/tests/parsers/postgres_simple_tasks/test_astro.sql
+++ b/tests/parsers/postgres_simple_tasks/test_astro.sql
@@ -2,4 +2,4 @@
 conn_id: postgres_conn
 database: pagila
 ---
-SELECT {{ params['foo'] }} FROM actor
+SELECT {{ params.foo }} FROM actor

--- a/tests/parsers/postgres_simple_tasks/test_astro.sql
+++ b/tests/parsers/postgres_simple_tasks/test_astro.sql
@@ -2,4 +2,4 @@
 conn_id: postgres_conn
 database: pagila
 ---
-SELECT * FROM actor
+SELECT {{ params['foo'] }} FROM actor

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -18,6 +18,8 @@ log = logging.getLogger(__name__)
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 import os
 
+from airflow.models.param import Param
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -30,6 +32,7 @@ class TestSQLParsing(unittest.TestCase):
                 "owner": "airflow",
                 "start_date": DEFAULT_DATE,
             },
+            params={"foo": Param("*")},
         )
 
     def tearDown(self):

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -32,7 +32,7 @@ class TestSQLParsing(unittest.TestCase):
                 "owner": "airflow",
                 "start_date": DEFAULT_DATE,
             },
-            params={"foo": Param("*")},
+            params={"foo": Param("first_name")},
         )
 
     def tearDown(self):


### PR DESCRIPTION
Clarifies in example dags that users can use `param` dictionary in their SQL files when using aql.render