### PR TITLE
Add CodeSpell as pre-commit check to avoid typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         args: [ "--profile", "black" ]
         files: \.py$
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        name: Run codespell to check for common misspellings in files
+        language: python
+        types: [text]
+
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v0.941'
       hooks:

--- a/conftest.py
+++ b/conftest.py
@@ -102,7 +102,7 @@ def test_table(request, sql_server):
         hook.run(f"DROP TABLE IF EXISTS {table.table_name}")
     elif not isinstance(hook, BigQueryHook):
         # There are some tests (e.g. test_agnostic_merge.py) which create stuff which are not being deleted
-        # Example: tables which are not fixtures and constraints. This is an agressive approach towards tearing down:
+        # Example: tables which are not fixtures and constraints. This is an aggressive approach towards tearing down:
         hook.run(f"DROP SCHEMA IF EXISTS {table.schema} CASCADE;")
 
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -67,7 +67,7 @@ After locating the pre-commit command, run:
 
 <!-- Tests don't run yet, we're missing `test-connections.yaml`. -->
 
-On all supported Pyhon versions:
+On all supported Python versions:
 
     nox -s test
 
@@ -75,7 +75,7 @@ On only 3.9 (for example):
 
     nox -s test-3.9
 
-Please also note that you can reuse an existing environtment if you run nox with the `-r` argument (or even `-R` if you
+Please also note that you can reuse an existing environment if you run nox with the `-r` argument (or even `-R` if you
 don't want to attempt to reinstall packages). This can significantly speed up repeat test runs.
 
 ## Check code coverage
@@ -83,7 +83,7 @@ don't want to attempt to reinstall packages). This can significantly speed up re
 To run code coverage locally, you can either use `pytest` in one of the test environments or
 run `nox -s test` with coverage arguments. We use [pytest-cov](https://pypi.org/project/pytest-cov/) for our coverage reporting.
 
-Below is an example of running a coverage report on a single test. In this case the relevent file is `src/astro/sql/operators/sql_decorator.py`
+Below is an example of running a coverage report on a single test. In this case the relevant file is `src/astro/sql/operators/sql_decorator.py`
 since we are testing the postgres `transform` decorator.
 
 ```shell script

--- a/docs/aep/README.md
+++ b/docs/aep/README.md
@@ -45,7 +45,7 @@ Congratulations! Your proposal has been accepted.
 
 Next up is breaking down tasks using the [Github Issues page](https://github.com/astro-projects/astro/issues/new).
 
-Ask a commiter to create a label for your AEP, and link all your issues with it for easier maintainability.
+Ask a committer to create a label for your AEP, and link all your issues with it for easier maintainability.
 
 We encourage you to involve the Astro community in reviewing the proposed tasks before they are implemented. **HOW?**
 

--- a/src/astro/utils/file.py
+++ b/src/astro/utils/file.py
@@ -50,7 +50,7 @@ def is_binary(filetype):
 
 def is_small(filepath):
     """
-    Checks if a file is small enough to be loaded into a Pandas dataframe in memory efficently.
+    Checks if a file is small enough to be loaded into a Pandas dataframe in memory efficiently.
     This value was obtained through performance tests.
 
     :param filepath: Path to a file in the filesystem

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -20,7 +20,7 @@ To download the sample datasets locally, run:
 GCS_BUCKET=<YOUR_GCS_BUCKEt> ./download_datasets.sh
 ```
 
-The GCS bucket `<YOUR_GCS_BUCKEt>` is only required to download the `github_timeline`, and you should have write permisions in this bucket.
+The GCS bucket `<YOUR_GCS_BUCKEt>` is only required to download the `github_timeline`, and you should have write permissions in this bucket.
 
 Summary of the sample datasets:
 

--- a/tests/operators/test_agnostic_save_file.py
+++ b/tests/operators/test_agnostic_save_file.py
@@ -108,7 +108,7 @@ class TestSaveFile(unittest.TestCase):
         return f
 
     def create_and_run_tasks(self, decorator_funcs):
-        # To Do: Merge create_and_run_tasks and create_and_run_task into a single fucntion.
+        # To Do: Merge create_and_run_tasks and create_and_run_task into a single function.
         tasks = []
         with self.dag:
             for decorator_func in decorator_funcs:


### PR DESCRIPTION
Uses https://github.com/codespell-project/codespell to check code for common misspellings