### PR TITLE
Simplify Code Coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s test_examples_by_dependency -- --cov=./ --cov-report=xml --cov-branch
+      - run: nox -s test_examples_by_dependency
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
@@ -106,7 +106,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s test -- --splits 12 --group ${{ matrix.group }} --cov=./ --cov-report=xml --cov-branch
+      - run: nox -s test -- --splits 12 --group ${{ matrix.group }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,8 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2%
-ignore:
-  - "test_*.py"
-  - "*/**/tests/*"
+        threshold: 5%
+        only_pulls: true
+  notify:
+    wait_for_ci: yes
+    after_n_builds: 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ Home = "https://astronomer.io/"
 provider_info = "astro.__init__:get_provider_info"
 
 [tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--cov=src --cov-report=xml --cov-branch"
 env_files = [".env"]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
This PR/commit:

- Moves codecov settings to `pyproject.toml` so we don't need to set it at each place in `ci.yaml`
- Explicitly sets `--cov=src` so we don't need to exclude "tests" or any other directory
- Also fixes issue where CodeCov comments and fails early after a single report is uploaded as we run our tests in parallel