### PR TITLE
Remove unused imports and add flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-complexity = 10
+max-line-length = 110
+select = F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,11 @@ repos:
         alias: black
         additional_dependencies: [black==22.1.0]
 
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1
     hooks:

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ from astro.settings import SCHEMA
 from astro.sql.table import Table, TempTable
 from astro.utils.cloud_storage_creds import parse_s3_env_var
 from astro.utils.database import get_database_name
-from astro.utils.dependencies import BigQueryHook, PostgresHook, SnowflakeHook, gcs, s3
+from astro.utils.dependencies import BigQueryHook, gcs, s3
 from src.astro.constants import FileType
 from tests.operators import utils as test_utils
 

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from datetime import datetime
 
 from airflow.decorators import dag
 from airflow.utils import timezone

--- a/src/astro/__init__.py
+++ b/src/astro/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.7.0"
 
-from astro.dataframe import dataframe
+from astro.dataframe import dataframe  # noqa: F401
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -1,17 +1,22 @@
 from typing import Callable, Iterable, List, Mapping, Optional, Union
 
-from astro.sql.operators.agnostic_aggregate_check import aggregate_check
-from astro.sql.operators.agnostic_boolean_check import boolean_check
-from astro.sql.operators.agnostic_load_file import load_file
-from astro.sql.operators.agnostic_save_file import save_file
+from astro.sql.operators.agnostic_aggregate_check import aggregate_check  # noqa: F401
+from astro.sql.operators.agnostic_boolean_check import boolean_check  # noqa: F401
+from astro.sql.operators.agnostic_load_file import load_file  # noqa: F401
+from astro.sql.operators.agnostic_save_file import save_file  # noqa: F401
 from astro.sql.operators.agnostic_sql_append import SqlAppendOperator
 from astro.sql.operators.agnostic_sql_merge import SqlMergeOperator
 from astro.sql.operators.agnostic_sql_truncate import SqlTruncateOperator
-from astro.sql.operators.agnostic_stats_check import OutlierCheck, stats_check
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator, transform_decorator
-from astro.sql.parsers.sql_directory_parser import render
+from astro.sql.operators.agnostic_stats_check import (  # noqa: F401
+    OutlierCheck,
+    stats_check,
+)
+from astro.sql.operators.sql_decorator import (  # noqa: F401
+    SqlDecoratedOperator,
+    transform_decorator,
+)
+from astro.sql.parsers.sql_directory_parser import render  # noqa: F401
 from astro.sql.table import Table
-from astro.utils.task_id_helper import get_task_id
 
 
 def transform(

--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -1,12 +1,7 @@
-from numbers import Number
-from typing import Dict, Optional
+from typing import Dict
 
-from airflow.exceptions import AirflowException
-from airflow.hooks.base import BaseHook
-from sqlalchemy import text
 from sqlalchemy.sql.schema import Table
 
-from astro import sql
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
 from astro.utils.task_id_helper import get_unique_task_id
 
@@ -32,11 +27,11 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
         :param check: SQL statement
         :type check: str
         :param greater_than: min expected value
-        :type greater_than: Number
+        :type greater_than: float
         :param less_than: max expected value
-        :type less_than: Number
+        :type less_than: float
         :param equal_to: expected value
-        :type equal_to: Number
+        :type equal_to: float
         :param conn_id: connection id
         :type conn_id: str
         :param database: database name

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 
 from airflow.hooks.base import BaseHook
 from sqlalchemy import FLOAT, and_, cast, column, func, select, text
-from sqlalchemy.sql.expression import table as sqlatable
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
 from astro.sql.table import Table

--- a/src/astro/sql/operators/agnostic_load_file.py
+++ b/src/astro/sql/operators/agnostic_load_file.py
@@ -9,21 +9,9 @@ from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.sql.table import Table, TempTable, create_table_name
 from astro.utils import get_hook
 from astro.utils.dependencies import gcs, s3
-from astro.utils.file import get_filetype, get_size, is_binary, is_small
-from astro.utils.load import (
-    copy_remote_file_to_local,
-    load_dataframe_into_sql_table,
-    load_file_into_dataframe,
-    load_file_into_sql_table,
-    load_file_rows_into_dataframe,
-)
-from astro.utils.path import (
-    get_location,
-    get_paths,
-    get_transport_params,
-    is_local,
-    validate_path,
-)
+from astro.utils.file import get_filetype
+from astro.utils.load import load_dataframe_into_sql_table, load_file_into_dataframe
+from astro.utils.path import get_paths, get_transport_params, validate_path
 from astro.utils.task_id_helper import get_task_id
 
 

--- a/src/astro/sql/operators/agnostic_save_file.py
+++ b/src/astro/sql/operators/agnostic_save_file.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional, Union
 from urllib.parse import urlparse
 

--- a/src/astro/sql/operators/agnostic_sql_append.py
+++ b/src/astro/sql/operators/agnostic_sql_append.py
@@ -10,7 +10,6 @@ from astro.sql.table import Table
 from astro.utils.database import get_database_name
 from astro.utils.schema_util import (
     get_error_string_for_multiple_dbs,
-    get_table_name,
     tables_from_same_db,
 )
 from astro.utils.table_handler import TableHandler

--- a/src/astro/sql/operators/agnostic_sql_merge.py
+++ b/src/astro/sql/operators/agnostic_sql_merge.py
@@ -1,10 +1,10 @@
-from typing import Dict, Union
+from typing import Dict
 
 from airflow.exceptions import AirflowException
 
 from astro.constants import Database
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
-from astro.sql.table import Table, TempTable
+from astro.sql.table import Table
 from astro.utils.bigquery_merge_func import bigquery_merge_func
 from astro.utils.database import get_database_from_conn_id
 from astro.utils.postgres_merge_func import postgres_merge_func

--- a/src/astro/sql/operators/agnostic_stats_check.py
+++ b/src/astro/sql/operators/agnostic_stats_check.py
@@ -75,7 +75,6 @@ class ChecksHandler:
     def prepare_cases_sql(self, main_stats, compare_table_sqla):
         cases = []
         for check in self.checks:
-
             cases.append(
                 case(
                     [

--- a/src/astro/sql/operators/sql_dataframe.py
+++ b/src/astro/sql/operators/sql_dataframe.py
@@ -5,7 +5,7 @@ import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 
-from astro.constants import DEFAULT_CHUNK_SIZE, Database
+from astro.constants import Database
 from astro.settings import SCHEMA
 from astro.sql.table import Table, TempTable, create_table_name
 from astro.utils import get_hook

--- a/src/astro/utils/bigquery_merge_func.py
+++ b/src/astro/utils/bigquery_merge_func.py
@@ -10,7 +10,7 @@ def bigquery_merge_func(
     conflict_strategy,
 ):
     statement = f"MERGE {target_table.qualified_name()} T USING {merge_table.qualified_name()} S\
-                ON {' AND '.join(['T.'+col +'= S.'+col for col in merge_keys])}\
+                ON {' AND '.join(['T.' + col + '= S.' + col for col in merge_keys])}\
                 WHEN NOT MATCHED BY TARGET THEN INSERT ({','.join(target_columns)}) VALUES ({','.join(merge_columns)})"
 
     if conflict_strategy == "update":

--- a/src/astro/utils/cloud_storage_creds.py
+++ b/src/astro/utils/cloud_storage_creds.py
@@ -1,16 +1,8 @@
-import json
 import os
-from urllib import parse
 
 from airflow.hooks.base import BaseHook
 
-from astro.utils.dependencies import (
-    AwsBaseHook,
-    BotoSession,
-    GCSClient,
-    GCSHook,
-    google_service_account,
-)
+from astro.utils.dependencies import AwsBaseHook, BotoSession, GCSClient, GCSHook
 
 
 def parse_s3_env_var():

--- a/src/astro/utils/dependencies.py
+++ b/src/astro/utils/dependencies.py
@@ -35,36 +35,30 @@ except ModuleNotFoundError:
         "airflow.providers.snowflake.hooks.snowflake", "snowflake"
     )
 
-
 try:
     from snowflake.connector import pandas_tools
 except ModuleNotFoundError:
     pandas_tools = MissingPackage("snowflake-connector-python[pandas]", "postgres")
-
 
 try:
     from boto3 import Session as BotoSession
 except ModuleNotFoundError:
     BotoSession = MissingPackage("s3fs", "amazon")
 
-
 try:
     from google.cloud.storage import Client as GCSClient
 except ModuleNotFoundError:
     GCSClient = MissingPackage("apache-airflow-providers-google", "google")
-
 
 try:
     from google.oauth2 import service_account as google_service_account
 except ModuleNotFoundError:
     google_service_account = MissingPackage("apache-airflow-providers-google", "google")
 
-
 try:
     from psycopg2 import sql as postgres_sql
 except ModuleNotFoundError:
     postgres_sql = MissingPackage("psycopg2", "postgres")
-
 
 try:
     from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -80,7 +74,6 @@ try:
     from airflow.providers.amazon.aws.hooks import s3
 except ModuleNotFoundError:
     s3 = MissingPackage("apache-airflow-providers-amazon", "amazon")
-
 
 try:
     from airflow.providers.google.cloud.hooks import gcs

--- a/src/astro/utils/load.py
+++ b/src/astro/utils/load.py
@@ -20,13 +20,8 @@ from astro.constants import (
     FileType,
 )
 from astro.sql.table import Table
-from astro.utils.database import get_database_name, get_sqlalchemy_engine, run_sql
-from astro.utils.dependencies import (
-    BigQueryHook,
-    PostgresHook,
-    SnowflakeHook,
-    pandas_tools,
-)
+from astro.utils.database import get_database_name, get_sqlalchemy_engine
+from astro.utils.dependencies import pandas_tools
 from astro.utils.file import get_filetype, get_size
 from astro.utils.schema_util import create_schema_query, schema_exists
 

--- a/src/astro/utils/path.py
+++ b/src/astro/utils/path.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 from urllib.parse import urlparse, urlunparse
 
-from astro.constants import FileLocation, FileType
+from astro.constants import FileLocation
 from astro.utils.cloud_storage_creds import gcs_client, s3fs_creds
 from astro.utils.dependencies import gcs, s3
 

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -1,4 +1,3 @@
-import os
 from typing import List
 
 from airflow.hooks.base import BaseHook
@@ -24,7 +23,6 @@ def schema_exists(hook, schema, conn_type):
 
 
 def create_schema_query(conn_type, hook, schema_id, user):
-
     if conn_type in ["postgresql", "postgres"]:
         return (
             postgres_sql.SQL(

--- a/src/astro/utils/snowflake_merge_func.py
+++ b/src/astro/utils/snowflake_merge_func.py
@@ -1,4 +1,3 @@
-import re
 from typing import List
 
 from airflow.exceptions import AirflowException

--- a/src/astro/utils/snowflake_transform.py
+++ b/src/astro/utils/snowflake_transform.py
@@ -1,6 +1,3 @@
-import inspect
-import re
-
 from astro.settings import SCHEMA
 from astro.sql.table import Table
 

--- a/tests/benchmark/analyse.py
+++ b/tests/benchmark/analyse.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import pathlib
 import sys
 
 import pandas as pd

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -8,7 +8,6 @@ import time
 import airflow
 import psutil
 from airflow.executors.debug_executor import DebugExecutor
-from airflow.models import DagBag
 from airflow.utils import timezone
 
 

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -16,7 +16,6 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 CWD = pathlib.Path(__file__).parent
 
-
 default_args = {
     "owner": "airflow",
     "retries": 1,

--- a/tests/miscellaneous/test_missing_package.py
+++ b/tests/miscellaneous/test_missing_package.py
@@ -23,16 +23,11 @@ Requires the unittest, pytest, and requests-mock Python libraries.
 """
 
 import logging
-import math
-import os
 import pathlib
 import sys
 import unittest.mock
 
-from airflow.models import DAG
 from airflow.utils import timezone
-from airflow.utils.state import State
-from airflow.utils.types import DagRunType
 
 log = logging.getLogger(__name__)
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)

--- a/tests/operators/test_agnostic_aggregate_check.py
+++ b/tests/operators/test_agnostic_aggregate_check.py
@@ -23,15 +23,9 @@ Requires the unittest, pytest, and requests-mock Python libraries.
 import logging
 import os
 import pathlib
-import random
-import unittest.mock
 
 import pytest
 from airflow.exceptions import BackfillUnfinished
-from airflow.hooks.sqlite_hook import SqliteHook
-from airflow.models import DAG, DagRun
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 
 import astro.sql as aql

--- a/tests/operators/test_agnostic_boolean_check.py
+++ b/tests/operators/test_agnostic_boolean_check.py
@@ -6,12 +6,9 @@ Requires the unittest, pytest, and requests-mock Python libraries.
 import logging
 import os
 import pathlib
-import time
-import unittest.mock
 
 import pytest
 from airflow.exceptions import BackfillUnfinished
-from airflow.models import DAG
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.utils import timezone
 
@@ -19,11 +16,7 @@ from airflow.utils import timezone
 import astro.sql as aql
 from astro.constants import SUPPORTED_DATABASES
 from astro.settings import SCHEMA
-from astro.sql.operators.agnostic_boolean_check import (
-    AgnosticBooleanCheck,
-    Check,
-    boolean_check,
-)
+from astro.sql.operators.agnostic_boolean_check import Check
 from astro.sql.table import Table
 from tests.operators.utils import get_table_name, run_dag
 
@@ -55,7 +48,6 @@ def drop_table_snowflake(
 
 @pytest.fixture(scope="module")
 def table(request):
-
     boolean_check_table = Table(
         get_table_name("boolean_check_test"),
         database="pagila",

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -17,12 +17,12 @@ from unittest import mock
 
 import pandas as pd
 import pytest
-from airflow.exceptions import BackfillUnfinished, DuplicateTaskIdFound
+from airflow.exceptions import BackfillUnfinished
 from airflow.utils import timezone
-from google.cloud import bigquery, storage
+from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 
-from astro.sql.operators.agnostic_load_file import AgnosticLoadFile, load_file
+from astro.sql.operators.agnostic_load_file import load_file
 from astro.sql.table import Table, TempTable
 from tests.operators import utils as test_utils
 

--- a/tests/operators/test_agnostic_save_file.py
+++ b/tests/operators/test_agnostic_save_file.py
@@ -37,7 +37,6 @@ import pandas as pd
 import pytest
 from airflow.models import DAG, DagRun
 from airflow.models import TaskInstance as TI
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 from airflow.utils.session import create_session

--- a/tests/operators/test_agnostic_stats_check.py
+++ b/tests/operators/test_agnostic_stats_check.py
@@ -9,11 +9,9 @@ import copy
 import logging
 import os
 import pathlib
-import unittest.mock
 from typing import Dict
 
 import pytest
-from airflow.models import DAG
 from airflow.utils import timezone
 
 # Import Operator

--- a/tests/operators/test_dataframe.py
+++ b/tests/operators/test_dataframe.py
@@ -25,8 +25,6 @@ from airflow.models import TaskInstance as TI
 from airflow.models.xcom import XCom
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from airflow.utils.state import State
-from airflow.utils.types import DagRunType
 
 from astro import dataframe as df
 from astro import sql as aql

--- a/tests/operators/test_sqlite_append.py
+++ b/tests/operators/test_sqlite_append.py
@@ -32,17 +32,13 @@ import time
 import unittest.mock
 
 import pandas as pd
-import pytest
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.hooks.sqlite_hook import SqliteHook
 from airflow.models import DAG, DagRun
 from airflow.models import TaskInstance as TI
-from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
-from airflow.utils.types import DagRunType
-from google.cloud import bigquery
 
 # Import Operator
 import astro.sql as aql
@@ -163,7 +159,6 @@ class TestSQLiteAppend(unittest.TestCase):
         assert df["rooms"].hasnans
 
     def test_append_all_fields(self):
-
         hook = SqliteHook(sqlite_conn_id="sqlite_conn")
 
         drop_table(table_name="test_main", postgres_conn=hook.get_conn())

--- a/tests/operators/transform/test_postgres_transform.py
+++ b/tests/operators/transform/test_postgres_transform.py
@@ -4,13 +4,12 @@ import pandas as pd
 import pytest
 from airflow.models import DAG, DagRun
 from airflow.models import TaskInstance as TI
-from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 
 import astro.sql as aql
 from astro import dataframe as adf
-from astro.sql.table import Table, TempTable
+from astro.sql.table import Table
 from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)

--- a/tests/operators/utils.py
+++ b/tests/operators/utils.py
@@ -8,7 +8,6 @@ from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from airflow.utils import timezone
 from airflow.utils.state import State
 
-from astro.settings import SCHEMA
 from astro.utils.dependencies import BigQueryHook, PostgresHook, SnowflakeHook
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)

--- a/tests/utils/test_load.py
+++ b/tests/utils/test_load.py
@@ -15,7 +15,6 @@ from astro.constants import (
 )
 from astro.settings import SCHEMA
 from astro.utils.database import get_sqlalchemy_engine
-from astro.utils.dependencies import PostgresHook
 from astro.utils.load import (
     copy_remote_file_to_local,
     load_dataframe_into_sql_table,


### PR DESCRIPTION
This PR removes tons of unused imports and adds flake8 so CI and pre-commits will fail next time it finds unused imports