### PR TITLE
Support `params` argument in `aql.render` to declare values to SQL Jinja template #125

### DIFF
--- a/src/astro/sql/parsers/sql_directory_parser.py
+++ b/src/astro/sql/parsers/sql_directory_parser.py
@@ -61,6 +61,7 @@ def render_single_path(
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
     role: Optional[str] = None,
+    **kwargs,
 ):
     # Parse all of the SQL files in this directory
     current_files = [
@@ -86,6 +87,8 @@ def render_single_path(
             operator_kwargs = set_kwargs_with_defaults(
                 front_matter_opts, conn_id, database, role, schema, warehouse
             )
+            if kwargs.get("params"):
+                operator_kwargs["params"] = kwargs.get("params")
 
             p = ParsedSqlOperator(
                 sql=sql,
@@ -169,8 +172,8 @@ def render(
             schema=schema,
             warehouse=warehouse,
             role=role,
+            **kwargs,
         )
-    print("Sdafasd")
 
     # Add the XComArg to the parameters to create dependency
     for filename in all_file_names:

--- a/src/astro/sql/parsers/sql_directory_parser.py
+++ b/src/astro/sql/parsers/sql_directory_parser.py
@@ -61,6 +61,7 @@ def render_single_path(
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
     role: Optional[str] = None,
+    params: Optional[dict] = None,
     **kwargs,
 ):
     # Parse all of the SQL files in this directory
@@ -87,8 +88,8 @@ def render_single_path(
             operator_kwargs = set_kwargs_with_defaults(
                 front_matter_opts, conn_id, database, role, schema, warehouse
             )
-            if kwargs.get("params"):
-                operator_kwargs["params"] = kwargs.get("params")
+            if params:
+                operator_kwargs["params"] = params
 
             p = ParsedSqlOperator(
                 sql=sql,
@@ -108,6 +109,7 @@ def render(
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
     role: Optional[str] = None,
+    params: Optional[dict] = None,
     **kwargs,
 ):
     """
@@ -141,6 +143,8 @@ def render(
     :param schema: schema name, can also be supplied in SQL frontmatter.
     :param warehouse: warehouse name (snowflake only), can also be supplied in SQL frontmatter.
     :param role: role name (snowflake only), can also be supplied in SQL frontmatter.
+    :param params: Parameters you want to pass to the sql file using the tradition {{ params.<your param> }} jinja
+    context. Made for backwards compatibility with existing Airflow scripts.
     :param kwargs: any kwargs you supply besides the ones mentioned will be passed on to the model rendering context.
     This means that if you have SQL file that inherits a table named `homes`, you can do something like this:
 
@@ -172,6 +176,7 @@ def render(
             schema=schema,
             warehouse=warehouse,
             role=role,
+            params=params,
             **kwargs,
         )
 

--- a/tests/parsers/single_task_dag/agg_orders.sql
+++ b/tests/parsers/single_task_dag/agg_orders.sql
@@ -1,1 +1,1 @@
-SELECT * FROM {{input_table}}
+SELECT {{params.col}} FROM {{input_table}}

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -107,6 +107,12 @@ class TestSQLParsing(unittest.TestCase):
         Runs two tasks with a direct dependency, the DAG will fail if task two can not
         inherit the table produced by task 1
         """
+
+        @adf
+        def validate_params(df: pd.DataFrame):
+            cols = df.columns.to_list()
+            assert cols == ["rooms"]
+
         with self.dag:
             cwd = pathlib.Path(__file__).parent
 
@@ -120,9 +126,10 @@ class TestSQLParsing(unittest.TestCase):
                     warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
                 ),
             )
-            aql.render(
+            models = aql.render(
                 "single_task_dag", input_table=input_table, params={"col": "rooms"}
             )
+            validate_params(models["inherit_task"])
         test_utils.run_dag(self.dag)
 
     def test_parse_to_dataframe(self):

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -20,7 +20,6 @@ from tests.operators import utils as test_utils
 log = logging.getLogger(__name__)
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
-
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -121,7 +120,9 @@ class TestSQLParsing(unittest.TestCase):
                     warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
                 ),
             )
-            aql.render("single_task_dag", input_table=input_table)
+            aql.render(
+                "single_task_dag", input_table=input_table, params={"col": "rooms"}
+            )
         test_utils.run_dag(self.dag)
 
     def test_parse_to_dataframe(self):


### PR DESCRIPTION
**Context**
At the moment, Astro 0.5.1 does not use the `params` keyword argument. This argument would allow us to overwrite SQL Jinja template values.

Example:
```
SELECT
   t.table_schema,
   t.table_name,
   CONCAT(t.table_catalog, '.', t.table_schema, '.', t.table_name) table_path
FROM dwh_legacy.information_schema.tables t
WHERE
       t.table_schema IN ({{ params.schemas }})
   AND t.table_type = 'BASE TABLE';
```

```
aql.render(path='/usr/local/airflow/include/sql/schemas',
                                      params={'schemas': dwh_schemas})
```

Currently raises the error:
```
  File "/sr/local/lib/python3.9/site-packages/jinja2/runtime.py", line 903, in _fail_with_undefined_error
      raise self._undefined_exception(self._undefined_message)
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'schemas'
```

**Acceptance criteria**
* Users of `aql.render` can override Jinja template values by using the `params`  argument
* Have an `example_dag` which uses `params`
* Add at least one unit test which validate this behaviour
* Update the docstring so it details this feature
* Ask @mag3141592 (bug reporter) to review the PR

This PR addresses one part of the previous PR that was not correctly implemented, namely the adding params at a task level as well as at the DAG level

addresses https://github.com/astro-projects/astro/issues/125