### PR TITLE
Fix `aql.dataframe` when table arg is absent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 
 [project.optional-dependencies]
 tests = [
+    "click==8.0.0",
     "pytest>=6.0",
     "pytest-split",
     "pytest-dotenv",

--- a/src/astro/utils/postgres_transform.py
+++ b/src/astro/utils/postgres_transform.py
@@ -4,9 +4,8 @@ from astro.utils.dependencies import PostgresHook
 
 def add_templates_to_context(parameters, context):
     for k, v in parameters.items():
-        if type(v) == Table:
-            final_name = v.schema + "." + v.table_name if v.schema else v.table_name
-            context[k] = final_name
+        if isinstance(v, Table):
+            context[k] = v.qualified_name()
         else:
             context[k] = ":" + k
     return context


### PR DESCRIPTION
Generate a valid unique table name with `df` arg
Fix #259

Co-authored-by: Julian LaNeve <lanevejulian@gmail.com>
Co-authored-by: Daniel Imberman <daniel.imberman@gmail.com>