### PR TITLE
Fix usages of mutable-default-args

### DIFF
--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -69,10 +69,14 @@ def run_raw_sql(
 def append(
     append_table: Table,
     main_table: Table,
-    columns: List[str] = [],
-    casted_columns: dict = {},
+    columns: Optional[List[str]] = None,
+    casted_columns: Optional[dict] = None,
     **kwargs,
 ):
+    if columns is None:
+        columns = []
+    if casted_columns is None:
+        casted_columns = {}
     return SqlAppendOperator(
         main_table=main_table,
         append_table=append_table,

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -1,5 +1,5 @@
 from distutils import log as logger
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from airflow.hooks.base import BaseHook
 from sqlalchemy import FLOAT, and_, cast, column, func, select, text
@@ -135,7 +135,9 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
         )
 
 
-def boolean_check(table: Table, checks: List[Check] = [], max_rows_returned: int = 100):
+def boolean_check(
+    table: Table, checks: Optional[List[Check]] = None, max_rows_returned: int = 100
+):
     """
     :param table: table name
     :type table: str
@@ -144,6 +146,8 @@ def boolean_check(table: Table, checks: List[Check] = [], max_rows_returned: int
     :param max_rows_returned: number of row returned if the check fails.
     :type max_rows_returned: int
     """
+    if checks is None:
+        checks = []
 
     return AgnosticBooleanCheck(
         table=table, checks=checks, max_rows_returned=max_rows_returned

--- a/src/astro/sql/operators/agnostic_sql_append.py
+++ b/src/astro/sql/operators/agnostic_sql_append.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from sqlalchemy import MetaData, cast, column, insert, select
 from sqlalchemy.sql.schema import Table as SqlaTable
@@ -23,10 +23,14 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
         self,
         append_table: Table,
         main_table: Table,
-        columns: List[str] = [],
-        casted_columns: dict = {},
+        columns: Optional[List[str]] = None,
+        casted_columns: Optional[dict] = None,
         **kwargs,
     ):
+        if columns is None:
+            columns = []
+        if casted_columns is None:
+            casted_columns = {}
         self.append_table = append_table
         self.main_table = main_table
         self.sql = ""

--- a/src/astro/sql/operators/agnostic_stats_check.py
+++ b/src/astro/sql/operators/agnostic_stats_check.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from sqlalchemy import MetaData, case, func, or_, select
 from sqlalchemy.sql.schema import Table as SqlaTable
@@ -266,7 +266,7 @@ class AgnosticStatsCheck(SqlDecoratedOperator):
 def stats_check(
     main_table: Table,
     compare_table: Table,
-    checks: List[OutlierCheck] = [],
+    checks: Optional[List[OutlierCheck]] = None,
     max_rows_returned: int = 100,
 ):
     """
@@ -279,6 +279,8 @@ def stats_check(
     :param max_rows_returned: number of row returned if the check fails.
     :type max_rows_returned: int
     """
+    if checks is None:
+        checks = []
 
     return AgnosticStatsCheck(
         main_table=main_table,

--- a/src/astro/sql/parsers/sql_directory_parser.py
+++ b/src/astro/sql/parsers/sql_directory_parser.py
@@ -237,7 +237,7 @@ class ParsedSqlOperator(SqlDecoratedOperator):
         sql,
         parameters,
         file_name,
-        op_kwargs={},
+        op_kwargs=None,
         conn_id: Optional[str] = None,
         database: Optional[str] = None,
         schema: Optional[str] = None,
@@ -245,6 +245,8 @@ class ParsedSqlOperator(SqlDecoratedOperator):
         role: Optional[str] = None,
         **kwargs,
     ):
+        if op_kwargs is None:
+            op_kwargs = {}
         self.sql = sql
         self.parameters = parameters
         task_id = get_unique_task_id(file_name.replace(".sql", ""))


### PR DESCRIPTION
Reference: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

Once we enable Pylint, it will catch the error:
https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/W0102.html