### PR TITLE
Improve `example_amazon_s3_snowflake_transform` dag

### DIFF
--- a/example_dags/example_amazon_s3_postgres.py
+++ b/example_dags/example_amazon_s3_postgres.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
@@ -6,6 +7,8 @@ from pandas import DataFrame
 from astro import sql as aql
 from astro.dataframe import dataframe as df
 from astro.sql.table import Table, TempTable
+
+s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
 default_args = {
     "owner": "airflow",
@@ -34,7 +37,7 @@ def my_df_func(input_df: DataFrame):
 
 with dag:
     my_homes_table = aql.load_file(
-        path="s3://tmp9/homes.csv",
+        path=f"{s3_bucket}/homes.csv",
         output_table=TempTable(
             database="pagila",
             conn_id="postgres_conn",

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -1,3 +1,5 @@
+import os
+
 from airflow.decorators import dag
 from airflow.utils import timezone
 
@@ -10,6 +12,7 @@ default_args = {
     "retries": 1,
     "retry_delay": 0,
 }
+s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
 
 @dag(
@@ -20,7 +23,7 @@ default_args = {
 )
 def example_amazon_s3_postgres_load_and_save():
     t1 = aql.load_file(
-        path="s3://tmp9/homes.csv",
+        path=f"{s3_bucket}/homes.csv",
         file_conn_id="",
         output_table=Table(
             "expected_table_from_s3", conn_id="postgres_conn", database="postgres"
@@ -29,7 +32,7 @@ def example_amazon_s3_postgres_load_and_save():
 
     aql.save_file(
         input=t1,
-        output_file_path="s3://tmp9/homes.csv",
+        output_file_path=f"{s3_bucket}/homes.csv",
         overwrite=True,
     )
 

--- a/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/example_dags/example_amazon_s3_snowflake_transform.py
@@ -46,6 +46,9 @@ def aggregate_data(df: pd.DataFrame):
     catchup=False,
 )
 def example_amazon_s3_snowflake_transform():
+
+    s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
+
     input_table_1 = Table(
         "ADOPTION_CENTER_1",
         database=os.environ["SNOWFLAKE_DATABASE"],
@@ -60,12 +63,12 @@ def example_amazon_s3_snowflake_transform():
     )
 
     temp_table_1 = aql.load_file(
-        path="s3://tmp9/ADOPTION_CENTER_1.csv",
+        path=f"{s3_bucket}/ADOPTION_CENTER_1.csv",
         file_conn_id="",
         output_table=input_table_1,
     )
     temp_table_2 = aql.load_file(
-        path="s3://tmp9/ADOPTION_CENTER_2.csv",
+        path=f"{s3_bucket}/ADOPTION_CENTER_2.csv",
         file_conn_id="",
         output_table=input_table_2,
     )

--- a/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/example_dags/example_amazon_s3_snowflake_transform.py
@@ -46,19 +46,33 @@ def aggregate_data(df: pd.DataFrame):
     catchup=False,
 )
 def example_amazon_s3_snowflake_transform():
+    input_table_1 = Table(
+        "ADOPTION_CENTER_1",
+        database=os.environ["SNOWFLAKE_DATABASE"],
+        schema=os.environ["SNOWFLAKE_SCHEMA"],
+        conn_id="snowflake_conn",
+    )
+    input_table_2 = Table(
+        "ADOPTION_CENTER_2",
+        database=os.environ["SNOWFLAKE_DATABASE"],
+        schema=os.environ["SNOWFLAKE_SCHEMA"],
+        conn_id="snowflake_conn",
+    )
+
+    temp_table_1 = aql.load_file(
+        path="s3://tmp9/ADOPTION_CENTER_1.csv",
+        file_conn_id="",
+        output_table=input_table_1,
+    )
+    temp_table_2 = aql.load_file(
+        path="s3://tmp9/ADOPTION_CENTER_2.csv",
+        file_conn_id="",
+        output_table=input_table_2,
+    )
+
     combined_data = combine_data(
-        center_1=Table(
-            "ADOPTION_CENTER_1",
-            database=os.environ["SNOWFLAKE_DATABASE"],
-            schema=os.environ["SNOWFLAKE_SCHEMA"],
-            conn_id="snowflake_conn",
-        ),
-        center_2=Table(
-            "ADOPTION_CENTER_2",
-            database=os.environ["SNOWFLAKE_DATABASE"],
-            schema=os.environ["SNOWFLAKE_SCHEMA"],
-            conn_id="snowflake_conn",
-        ),
+        center_1=temp_table_1,
+        center_2=temp_table_2,
     )
 
     cleaned_data = clean_data(combined_data)

--- a/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -12,6 +12,7 @@ Pre-requisites:
  - You can either specify a service account key file and set `GOOGLE_APPLICATION_CREDENTIALS`
     with the file path to the service account.
 """
+import os
 
 import pandas as pd
 from airflow.models.dag import DAG
@@ -20,6 +21,8 @@ from airflow.utils import timezone
 import astro.sql as aql
 from astro import dataframe
 from astro.sql.table import Table
+
+gcs_bucket = os.getenv("GCS_BUCKET", "gs://dag-authoring")
 
 with DAG(
     dag_id="example_google_bigquery_gcs_load_and_save",
@@ -47,7 +50,7 @@ with DAG(
     aql.save_file(
         task_id="save_to_gcs",
         input=t2,
-        output_file_path="gs://dag-authoring/{{ task_instance_key_str }}/top_5_movies.csv",
+        output_file_path=f"{gcs_bucket}/{{ task_instance_key_str }}/top_5_movies.csv",
         output_file_format="csv",
         output_conn_id="gcp_conn",
         overwrite=True,


### PR DESCRIPTION
Closes: #136

example_amazon_s3_snowflake_transform.py was using prepopulated tables in the snowflake database.

Removed dependency from prepopulated tables by using the `load_file` operator. 
