### PR TITLE
Enable MyPy on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,31 @@ jobs:
           path: ~/.cache/pip
           key: ${{ hashFiles('pyproject.toml') }}
       - uses: pre-commit/action@v2.0.3
+  Mypy:
+    runs-on: ubuntu-latest
+    name: Mypy
+    env:
+      MYPY_FORCE_COLOR: 1
+      TERM: xterm-color
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: mypy-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+      - name: Install Dependencies
+        run: |
+          pip install wheel
+          pip install -U -e .[all,mypy]
+      - name: Run Mypy
+        run: |
+          mypy --version
+          mypy
   Run-Optional-Packages-tests:
     runs-on: ubuntu-latest
     services:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,12 +75,6 @@ repos:
         language: python
         types: [text]
 
-  -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v0.942'
-      hooks:
-      -   id: mypy
-          additional_dependencies: [types-PyYAML]
-
   -   repo: https://github.com/asottile/pyupgrade
       rev: v2.31.1
       hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ all = [
 doc = [
     "sphinx==4.4.0"
 ]
+mypy = [
+    "mypy",
+    "types-PyYAML"
+]
 
 [project.urls]
 Home = "https://astronomer.io/"
@@ -91,6 +95,33 @@ testpaths = ["tests"]
 markers = [
     "integration"
 ]
+addopts = "--color=yes"
 
 [tool.flit.module]
 name = "astro"  # Or "astro.sql" if you just want this directory, not the entire 'astro'.
+
+[tool.mypy]
+namespace_packages = true
+explicit_package_bases = true
+pretty = true
+show_error_codes = true
+ignore_missing_imports = true
+no_implicit_optional = true
+warn_redundant_casts = true
+show_error_context = true
+color_output = true
+disallow_any_generics = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_return_any = true
+strict_equality = true
+files = ["src"]
+
+# mypy per-module options:
+[[tool.mypy.overrides]]
+module = [
+    "airflow",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
closes https://github.com/astro-projects/astro/issues/280

This PR removes Mypy from pre-commit-hook as it is not reliable to run MyPy on local system as it depends on Python version and installed packages and pre-commit runs it in a virtualenv.

We can instead rely on CI and in future add Make command to run it inside a container same as https://github.com/astronomer/astronomer-providers/blob/main/Makefile#L54-L59