### PR TITLE
Enrich modules with TypeHints (part 2/9)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+min_python_version = 3.7
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 12
 max-line-length = 120

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,10 @@ jobs:
   Type-Check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.8'
           architecture: 'x64'
       - run: pip3 install nox
       - run: nox -s type_check
@@ -45,10 +45,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.8'
           architecture: 'x64'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,12 @@ jobs:
   Pre-Commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.9'
           architecture: 'x64'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ hashFiles('pyproject.toml') }}
@@ -21,12 +21,21 @@ jobs:
 
   Type-Check:
     runs-on: ubuntu-latest
+    env:
+      MYPY_FORCE_COLOR: 1
+      TERM: xterm-color
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
           architecture: 'x64'
+      - uses: actions/cache@v3
+        with:
+           path: |
+             ~/.cache/pip
+             .nox
+           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - run: pip3 install nox
       - run: nox -s type_check
 
@@ -45,12 +54,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
           architecture: 'x64'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -108,12 +117,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
           architecture: 'x64'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -158,9 +167,9 @@ jobs:
       - Run-Optional-Packages-tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - name: Install coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,18 @@ jobs:
           path: ~/.cache/pip
           key: ${{ hashFiles('pyproject.toml') }}
       - uses: pre-commit/action@v2.0.3
+
+  Type-Check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+      - run: pip3 install nox
+      - run: nox -s type_check
+
   Run-Optional-Packages-tests:
     runs-on: ubuntu-latest
     services:
@@ -33,10 +45,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
       - uses: actions/cache@v2
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,15 @@ def test(session: nox.Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-@nox.session()
+@nox.session(python=["3.10"])
+def type_check(session: nox.Session) -> None:
+    """Run MyPy checks."""
+    session.install("-e", ".[all]")
+    session.install("-e", ".[tests]")
+    session.run("mypy")
+
+
+@nox.session(python=["3.10"])
 @nox.parametrize(
     "extras",
     [

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ def test(session: nox.Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-@nox.session(python=["3.10"])
+@nox.session(python=["3.8"])
 def type_check(session: nox.Session) -> None:
     """Run MyPy checks."""
     session.install("-e", ".[all]")
@@ -37,7 +37,7 @@ def type_check(session: nox.Session) -> None:
     session.run("mypy")
 
 
-@nox.session(python=["3.10"])
+@nox.session()
 @nox.parametrize(
     "extras",
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Database",
 ]
 
@@ -43,7 +44,9 @@ tests = [
     "pytest-dotenv",
     "requests-mock",
     "pytest-cov",
-    "pytest-describe"
+    "pytest-describe",
+    "mypy",
+    "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
     "apache-airflow-providers-google",
@@ -94,3 +97,12 @@ markers = [
 
 [tool.flit.module]
 name = "astro"  # Or "astro.sql" if you just want this directory, not the entire 'astro'.
+
+[tool.mypy]
+files = [
+    "src/astro/settings.py",
+    "src/astro/sql/__init__.py",
+    "src/astro/sql/operators/agnostic_aggregate_check.py",
+    "src/astro/sql/operators/agnostic_boolean_check.py"
+]
+follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Topic :: Database",
 ]
 
@@ -99,6 +98,12 @@ markers = [
 name = "astro"  # Or "astro.sql" if you just want this directory, not the entire 'astro'.
 
 [tool.mypy]
+color_output = true
+#disallow_any_generics = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#explicit_package_bases = true
+# TODO: Once we complete #281 we can replace the files parameter by the mypy_path
 files = [
     "src/astro/settings.py",
     "src/astro/sql/__init__.py",
@@ -106,3 +111,12 @@ files = [
     "src/astro/sql/operators/agnostic_boolean_check.py"
 ]
 follow_imports = "skip"
+namespace_packages = true
+no_implicit_optional = true
+pretty = true
+strict_equality = true
+show_error_codes = true
+show_error_context = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -50,7 +50,7 @@ def run_raw_sql(
     database: Optional[str] = None,
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
-    handler: Callable = None,
+    handler: Optional[Callable] = None,
 ):
     return transform_decorator(
         python_callable=python_callable,

--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from airflow.utils.context import Context
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
@@ -12,9 +14,9 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
         self,
         table: Table,
         check: str,
-        greater_than: float = None,
-        less_than: float = None,
-        equal_to: float = None,
+        greater_than: Optional[float] = None,
+        less_than: Optional[float] = None,
+        equal_to: Optional[float] = None,
         **kwargs,
     ):
         """Validate that a table has expected aggregation value.
@@ -111,9 +113,9 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
 def aggregate_check(
     table: Table,
     check: str,
-    greater_than: float = None,
-    less_than: float = None,
-    equal_to: float = None,
+    greater_than: Optional[float] = None,
+    less_than: Optional[float] = None,
+    equal_to: Optional[float] = None,
 ) -> AgnosticAggregateCheck:
     """
     :param table: table name

--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -1,8 +1,7 @@
-from typing import Dict
-
-from sqlalchemy.sql.schema import Table
+from airflow.utils.context import Context
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.table import Table
 from astro.utils.task_id_helper import get_unique_task_id
 
 
@@ -23,19 +22,12 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
         equal_to can be used to check a value.
 
         :param table: table name
-        :type table: str
         :param check: SQL statement
-        :type check: str
         :param greater_than: min expected value
-        :type greater_than: float
         :param less_than: max expected value
-        :type less_than: float
         :param equal_to: expected value
-        :type equal_to: float
         :param conn_id: connection id
-        :type conn_id: str
         :param database: database name
-        :type database: str
         """
         self.table = table
         self.check = check
@@ -75,7 +67,7 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
             **kwargs,
         )
 
-    def execute(self, context: Dict):
+    def execute(self, context: Context) -> Table:
         self.conn_id = self.table.conn_id
         self.database = self.table.database
         self.sql = self.check
@@ -122,7 +114,7 @@ def aggregate_check(
     greater_than: float = None,
     less_than: float = None,
     equal_to: float = None,
-):
+) -> AgnosticAggregateCheck:
     """
     :param table: table name
     :type table: str

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -3,6 +3,8 @@ from typing import Dict, List, Optional
 
 from airflow.hooks.base import BaseHook
 from sqlalchemy import FLOAT, and_, cast, column, func, select, text
+from sqlalchemy.sql.elements import TextClause
+from sqlalchemy.sql.selectable import Select
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
 from astro.sql.table import Table
@@ -20,32 +22,26 @@ class Check:
         self.expression = expression
         self.threshold = threshold
 
-    def get_expression(self):
+    def get_expression(self) -> TextClause:
         return text(f"CASE WHEN {self.expression} THEN 0 ELSE 1 END AS {self.name}")
 
     def get_result(self):
-        return cast(func.sum(column(self.name)), FLOAT) / func.count().label(
+        value = cast(func.sum(column(self.name)), FLOAT) / func.count().label(
             self.name + "_result"
         )
+        return value
 
 
 class AgnosticBooleanCheck(SqlDecoratedOperator):
     template_fields = ("table",)
 
     def __init__(
-        self,
-        checks: List[Check],
-        table: Table,
-        max_rows_returned: int,
-        **kwargs,
-    ):
+        self, checks: List[Check], table: Table, max_rows_returned: int, **kwargs
+    ) -> None:
         """
         :param table: table to check
-        :type table: Table
         :param checks: check class object, which represent boolean expression
-        :type checks: Check
         :param max_rows_returned: number of row returned if the check fails.
-        :type max_rows_returned: int
         """
 
         self.table = table
@@ -57,7 +53,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
         def handler_func(results):
             return results.fetchall()
 
-        def null_function():
+        def null_function() -> None:
             pass
 
         super().__init__(
@@ -109,7 +105,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
 
     def prep_boolean_checks_query(
         self, table: Table, checks: List[Check], context: Dict
-    ):
+    ) -> Select:
 
         sqla_checks_object = []
         context = self._add_templates_to_context(context)
@@ -119,6 +115,13 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
                 AgnosticBooleanCheck.get_expression(prepared_exp, check.name)
             )
 
+        # ATM we are using SQLAlchemy 1.3.24 and, therefore, the package sqlalchemy-stubs to allow type checks.
+        # SQLAlchemy `select_from` supports an argument of type `text`, but `sqlalchemy-stubs` does not recognise this.
+        # An attempt to solve this issue was to replace text(table.qualified_name()) by an SQLAlchemy table, but this
+        # broken this feature (by introducing table names with double quotes).
+        # Since we'll soon upgrade to SQLAlchemy 1.4.x, and the type validation changes significantly, it felt the best
+        # for now was to ignore this particular type check issue.
+        # More information on this topic: https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
         temp_table = (
             select(sqla_checks_object)
             .select_from(text(table.qualified_name()))  # type: ignore
@@ -129,7 +132,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
     def prep_results(self, results):
         return (
             select(["*"])
-            .select_from(text(self.table.qualified_name()))  # type: ignore
+            .select_from(text(self.table.qualified_name()))
             .where(and_(*[text(self.checks[index].expression) for index in results]))
             .limit(self.max_rows_returned)
         )
@@ -137,7 +140,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
 
 def boolean_check(
     table: Table, checks: Optional[List[Check]] = None, max_rows_returned: int = 100
-):
+) -> AgnosticBooleanCheck:
     """
     :param table: table name
     :type table: str

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -121,7 +121,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
 
         temp_table = (
             select(sqla_checks_object)
-            .select_from(text(table.qualified_name()))
+            .select_from(text(table.qualified_name()))  # type: ignore
             .alias("check_table")
         )
         return select([check.get_result() for check in checks]).select_from(temp_table)
@@ -129,7 +129,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
     def prep_results(self, results):
         return (
             select(["*"])
-            .select_from(text(self.table.qualified_name()))
+            .select_from(text(self.table.qualified_name()))  # type: ignore
             .where(and_(*[text(self.checks[index].expression) for index in results]))
             .limit(self.max_rows_returned)
         )

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -27,8 +27,8 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         self,
         conn_id: Optional[str] = None,
         autocommit: bool = False,
-        parameters: dict = None,
-        handler: Function = None,
+        parameters: Optional[dict] = None,
+        handler: Optional[Function] = None,
         database: Optional[str] = None,
         schema: Optional[str] = None,
         warehouse: Optional[str] = None,
@@ -182,7 +182,9 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             }
         self.parameters.update(self.op_kwargs)  # type: ignore
 
-    def handle_output_table_schema(self, output_table_name, schema=None) -> str:
+    def handle_output_table_schema(
+        self, output_table_name: str, schema: Optional[str] = None
+    ) -> str:
         """
         In postgres, we set the schema in the query itself instead of as a query parameter.
         This function adds the necessary {schema}.{table} notation.
@@ -373,7 +375,7 @@ def transform_decorator(
     schema: Optional[str] = None,
     warehouse: Optional[str] = None,
     raw_sql: bool = False,
-    handler: Callable = None,
+    handler: Optional[Callable] = None,
 ):
     """
     :param python_callable:

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import Optional
 
 from airflow.hooks.base import BaseHook
 from airflow.models import DagRun, TaskInstance
@@ -90,7 +91,7 @@ class TempTable(Table):
             schema=schema,
         )
 
-    def to_table(self, table_name: str, schema: str = None) -> Table:
+    def to_table(self, table_name: str, schema: Optional[str] = None) -> Table:
         self.table_name = table_name
         self.schema = schema or self.schema or SCHEMA
 

--- a/src/astro/utils/__init__.py
+++ b/src/astro/utils/__init__.py
@@ -1,10 +1,19 @@
+from typing import Type, Union
+
 from airflow.hooks.base import BaseHook
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 
-from astro.utils.dependencies import BigQueryHook, PostgresHook, SnowflakeHook
+from astro.utils.dependencies import (
+    BigQueryHook,
+    MissingPackage,
+    PostgresHook,
+    SnowflakeHook,
+)
 
 
-def get_hook(conn_id, database, role=None, schema=None, warehouse=None):
+def get_hook(
+    conn_id, database, role=None, schema=None, warehouse=None
+) -> Union[BigQueryHook, PostgresHook, SqliteHook, SnowflakeHook, Type[MissingPackage]]:
     """
     Retrieve the relevant Airflow hook depending on the given arguments.
     """

--- a/src/astro/utils/dependencies.py
+++ b/src/astro/utils/dependencies.py
@@ -1,86 +1,105 @@
 from astro import constants
 
 
-class MissingPackage:
-    def __init__(self, module_name, related_extras):
-        self.module_name = module_name
-        self.related_extras = related_extras
+class MissingPackage(type):
+    """
+    Base class used to handle missing packages.
+    Raises an exception if the user attempts to access a class attribute.
+    """
 
-    def __getattr__(self, item):
+    package_name: str = ""
+    related_extras: str = ""
+
+    def __getattr__(cls, key: str) -> None:
         raise RuntimeError(
-            f"Error loading the module {self.module_name},"
+            f"Error loading the package {cls.package_name},"
             f" please make sure all the dependencies are installed."
-            f" try - pip install {constants.PYPI_PROJECT_NAME}[{self.related_extras}]"
+            f" try - pip install {constants.PYPI_PROJECT_NAME}[{cls.related_extras}]"
         )
 
 
-try:
-    from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-except ModuleNotFoundError:
-    BigQueryHook = MissingPackage(
-        "airflow.providers.google.cloud.hooks.bigquery", "google"
-    )
+class GoogleMissingPackage(metaclass=MissingPackage):
+    """
+    Class used to represent missing dependencies related to Google services.
+    """
+
+    package_name = "apache-airflow-providers-google"
+    related_extras = "google"
+
+
+class AmazonMissingPackage(metaclass=MissingPackage):
+    """
+    Class used to represent missing dependencies related to Amazon services.
+    """
+
+    package_name = "apache-airflow-providers-amazon"
+    related_extras = "amazon"
+
+
+class SnowflakeMissingPackage(metaclass=MissingPackage):
+    """
+    Class used to represent missing dependencies related to Snowflake.
+    """
+
+    package_name = "apache-airflow-providers-snowflake"
+    related_extras = "snowflake"
+
+
+class SnowflakePandasMissingPackage(metaclass=MissingPackage):
+    """
+    Class used to represent missing dependencies related to Snowflake & Pandas.
+    """
+
+    package_name = "snowflake-connector-python[pandas]"
+    related_extras = "snowflake"
+
+
+class PostgresMissingPackage(metaclass=MissingPackage):
+    """
+    Class used to represent missing dependencies related to Postgres.
+    """
+
+    package_name = "apache-airflow-providers-postgres"
+    related_extras = "postgres"
+
 
 try:
     from airflow.providers.postgres.hooks.postgres import PostgresHook
+    from psycopg2 import sql as postgres_sql
 except ModuleNotFoundError:
-    PostgresHook = MissingPackage(
-        "airflow.providers.postgres.hooks.postgres", "postgres"
-    )
+    PostgresHook = PostgresMissingPackage
+    postgres_sql = PostgresMissingPackage
 
 try:
     from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 except ModuleNotFoundError:
-    SnowflakeHook = MissingPackage(
-        "airflow.providers.snowflake.hooks.snowflake", "snowflake"
-    )
+    SnowflakeHook = SnowflakeMissingPackage
 
 try:
     from snowflake.connector import pandas_tools
 except ModuleNotFoundError:
-    pandas_tools = MissingPackage("snowflake-connector-python[pandas]", "postgres")
-
-try:
-    from boto3 import Session as BotoSession
-except ModuleNotFoundError:
-    BotoSession = MissingPackage("s3fs", "amazon")
-
-try:
-    from google.cloud.storage import Client as GCSClient
-except ModuleNotFoundError:
-    GCSClient = MissingPackage("apache-airflow-providers-google", "google")
-
-try:
-    from google.cloud import bigquery
-except ModuleNotFoundError:
-    bigquery = MissingPackage("apache-airflow-providers-google", "google")
-
-try:
-    from google.oauth2 import service_account as google_service_account
-except ModuleNotFoundError:
-    google_service_account = MissingPackage("apache-airflow-providers-google", "google")
-
-try:
-    from psycopg2 import sql as postgres_sql
-except ModuleNotFoundError:
-    postgres_sql = MissingPackage("psycopg2", "postgres")
-
-try:
-    from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-except ModuleNotFoundError:
-    AwsBaseHook = MissingPackage("apache-airflow-providers-amazon", "amazon")
-
-try:
-    from airflow.providers.google.cloud.hooks.gcs import GCSHook
-except ModuleNotFoundError:
-    GCSHook = MissingPackage("apache-airflow-providers-google", "google")
+    pandas_tools = SnowflakePandasMissingPackage
 
 try:
     from airflow.providers.amazon.aws.hooks import s3
+    from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+    from boto3 import Session as BotoSession
 except ModuleNotFoundError:
-    s3 = MissingPackage("apache-airflow-providers-amazon", "amazon")
+    s3 = AmazonMissingPackage
+    AwsBaseHook = AmazonMissingPackage
+    BotoSession = AmazonMissingPackage
 
 try:
     from airflow.providers.google.cloud.hooks import gcs
+    from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+    from airflow.providers.google.cloud.hooks.gcs import GCSHook
+    from google.cloud import bigquery
+    from google.cloud.storage import Client as GCSClient
+    from google.oauth2 import service_account as google_service_account
 except ModuleNotFoundError:
-    gcs = MissingPackage("apache-airflow-providers-google", "google")
+    BigQueryHook = GoogleMissingPackage
+    bigquery = GoogleMissingPackage
+    GCSClient = GoogleMissingPackage
+    GCSHook = GoogleMissingPackage
+    gcs = GoogleMissingPackage
+    google_service_account = GoogleMissingPackage

--- a/src/astro/utils/dependencies.py
+++ b/src/astro/utils/dependencies.py
@@ -19,45 +19,35 @@ class MissingPackage(type):
 
 
 class GoogleMissingPackage(metaclass=MissingPackage):
-    """
-    Class used to represent missing dependencies related to Google services.
-    """
+    """Class used to represent missing dependencies related to Google services."""
 
     package_name = "apache-airflow-providers-google"
     related_extras = "google"
 
 
 class AmazonMissingPackage(metaclass=MissingPackage):
-    """
-    Class used to represent missing dependencies related to Amazon services.
-    """
+    """Class used to represent missing dependencies related to Amazon services."""
 
     package_name = "apache-airflow-providers-amazon"
     related_extras = "amazon"
 
 
 class SnowflakeMissingPackage(metaclass=MissingPackage):
-    """
-    Class used to represent missing dependencies related to Snowflake.
-    """
+    """Class used to represent missing dependencies related to Snowflake."""
 
     package_name = "apache-airflow-providers-snowflake"
     related_extras = "snowflake"
 
 
 class SnowflakePandasMissingPackage(metaclass=MissingPackage):
-    """
-    Class used to represent missing dependencies related to Snowflake & Pandas.
-    """
+    """Class used to represent missing dependencies related to Snowflake & Pandas."""
 
     package_name = "snowflake-connector-python[pandas]"
     related_extras = "snowflake"
 
 
 class PostgresMissingPackage(metaclass=MissingPackage):
-    """
-    Class used to represent missing dependencies related to Postgres.
-    """
+    """Class used to represent missing dependencies related to Postgres."""
 
     package_name = "apache-airflow-providers-postgres"
     related_extras = "postgres"
@@ -81,18 +71,18 @@ except ModuleNotFoundError:
     pandas_tools = SnowflakePandasMissingPackage
 
 try:
-    from airflow.providers.amazon.aws.hooks import s3
-    from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+    from airflow.providers.amazon.aws.hooks import base_aws, s3  # skipcq: PYL-C0412
     from boto3 import Session as BotoSession
 except ModuleNotFoundError:
     s3 = AmazonMissingPackage
     AwsBaseHook = AmazonMissingPackage
     BotoSession = AmazonMissingPackage
+else:
+    AwsBaseHook = base_aws.AwsBaseHook  # type: ignore
 
 try:
-    from airflow.providers.google.cloud.hooks import gcs
+    from airflow.providers.google.cloud.hooks import gcs  # skipcq: PYL-C0412
     from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-    from airflow.providers.google.cloud.hooks.gcs import GCSHook
     from google.cloud import bigquery
     from google.cloud.storage import Client as GCSClient
     from google.oauth2 import service_account as google_service_account
@@ -103,3 +93,5 @@ except ModuleNotFoundError:
     GCSHook = GoogleMissingPackage
     gcs = GoogleMissingPackage
     google_service_account = GoogleMissingPackage
+else:
+    GCSHook = gcs.GCSHook  # type: ignore

--- a/src/astro/utils/file.py
+++ b/src/astro/utils/file.py
@@ -33,10 +33,9 @@ def get_filetype(filepath: Union[str, pathlib.PosixPath]) -> FileType:
         extension = filepath.split(".")[-1]
 
     try:
-        filetype = getattr(FileType, extension.upper())
-    except AttributeError:
+        return FileType[extension.upper()]
+    except KeyError:
         raise ValueError(f"Unsupported filetype '{extension}' from file '{filepath}'.")
-    return filetype
 
 
 def is_binary(filetype: FileType) -> bool:
@@ -64,4 +63,4 @@ def is_small(filepath: str) -> bool:
     :rtype: boolean
     """
     size_in_bytes = get_size(filepath)
-    return size_in_bytes <= LOAD_DATAFRAME_BYTES_LIMIT
+    return bool(size_in_bytes <= LOAD_DATAFRAME_BYTES_LIMIT)

--- a/src/astro/utils/load.py
+++ b/src/astro/utils/load.py
@@ -4,7 +4,7 @@ Functions for loading data from a source location to a destination location.
 import io
 import json
 import tempfile
-from typing import Union
+from typing import Optional, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -30,9 +30,9 @@ from astro.utils.schema_util import create_schema_query, schema_exists
 
 def load_file_into_dataframe(
     filepath: str,
-    filetype: FileType = None,
-    transport_params: Union[None, dict] = None,
-    normalize_config: Union[None, dict] = None,
+    filetype: Optional[FileType] = None,
+    transport_params: Optional[dict] = None,
+    normalize_config: Optional[dict] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -134,7 +134,7 @@ def populate_normalize_config(ndjson_normalize_sep, database: Database) -> dict:
 
 def load_file_rows_into_dataframe(
     filepath: str,
-    filetype: FileType = None,
+    filetype: Optional[FileType] = None,
     rows_count: int = LOAD_COLUMN_AUTO_DETECT_ROWS,
 ) -> pd.DataFrame:
     """
@@ -293,9 +293,9 @@ def load_dataframe_into_sql_table(
 
 def copy_remote_file_to_local(
     source_filepath: str,
-    target_filepath: str = None,
+    target_filepath: Optional[str] = None,
     is_binary: bool = False,
-    transport_params: Union[None, dict] = None,
+    transport_params: Optional[dict] = None,
 ) -> str:
     """
     Copy the contents of a file (which may be available locally or remotely) to a local file.

--- a/tests/miscellaneous/test_missing_package.py
+++ b/tests/miscellaneous/test_missing_package.py
@@ -63,7 +63,7 @@ class TestMissingPackages(unittest.TestCase):
 
             assert (
                 str(error.value)
-                == "Error loading the module airflow.providers.google.cloud.hooks.bigquery,"
+                == "Error loading the package apache-airflow-providers-google,"
                 " please make sure all the dependencies are installed. try - pip install"
                 " astro-projects[google]"
             )
@@ -77,7 +77,7 @@ class TestMissingPackages(unittest.TestCase):
 
             assert (
                 str(error.value)
-                == "Error loading the module airflow.providers.postgres.hooks.postgres,"
+                == "Error loading the package apache-airflow-providers-postgres,"
                 " please make sure all the dependencies are installed. try - pip install"
                 " astro-projects[postgres]"
             )
@@ -91,7 +91,7 @@ class TestMissingPackages(unittest.TestCase):
 
             assert (
                 str(error.value)
-                == "Error loading the module airflow.providers.snowflake.hooks.snowflake,"
+                == "Error loading the package apache-airflow-providers-snowflake,"
                 " please make sure all the dependencies are installed. try - pip install"
                 " astro-projects[snowflake]"
             )


### PR DESCRIPTION
Part of #281

Add TypeHints to the following modules:
```
│   ├── settings.py
│   ├── sql
│   │   ├── __init__.py
│   │   ├── operators
│   │   │   ├── agnostic_aggregate_check.py
│   │   │   ├── agnostic_boolean_check.py
```

During the development of this PR, there were a few complaints from DeepSource, related to pre-conditions of the code.
Those are being addressed in a separate PR: https://github.com/astro-projects/astro/pull/299
