### PR TITLE
Refactored testcase for truncate operator.

### DIFF
--- a/tests/operators/test_agnostic_truncate.py
+++ b/tests/operators/test_agnostic_truncate.py
@@ -52,6 +52,7 @@ CWD = pathlib.Path(__file__).parent
     indirect=True,
 )
 def test_truncate(sql_server, test_table, sample_dag):
+    """Test truncate operator for all databases."""
     sql_name, hook = sql_server
     df = test_utils.get_dataframe_from_table(sql_name, test_table, hook)
     assert df.count()[0] == 5

--- a/tests/operators/test_agnostic_truncate.py
+++ b/tests/operators/test_agnostic_truncate.py
@@ -7,91 +7,59 @@ Requires the unittest, pytest, and requests-mock Python libraries.
 
 import logging
 import pathlib
-import unittest
 
-from airflow.models import DAG
-from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+import pytest
 from airflow.utils import timezone
 
 # Import Operator
 import astro.sql as aql
-from astro.sql.table import Table
+from astro.settings import SCHEMA
+from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+CWD = pathlib.Path(__file__).parent
 
 
-def drop_table(table_name, postgres_conn):
-    cursor = postgres_conn.cursor()
-    cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE;")
-    postgres_conn.commit()
-    cursor.close()
-    postgres_conn.close()
-
-
-class TestPostgresTruncateOperator(unittest.TestCase):
-    """
-    Test Postgres Merge Operator.
-    """
-
-    cwd = pathlib.Path(__file__).parent
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-    def clear_run(self):
-        self.run = False
-
-    def setUp(self):
-        super().setUp()
-        self.clear_run()
-        self.addCleanup(self.clear_run)
-        self.dag = DAG(
-            "test_dag",
-            default_args={
-                "owner": "airflow",
-                "start_date": DEFAULT_DATE,
+@pytest.mark.parametrize(
+    "sql_server",
+    [
+        pytest.param(
+            "bigquery",
+            marks=pytest.mark.xfail(
+                reason="400 DELETE must have a WHERE clause at [1:1]"
+            ),
+        ),
+        "snowflake",
+        "postgres",
+        "sqlite",
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "test_table",
+    [
+        {
+            "path": str(CWD) + "/../data/homes2.csv",
+            "load_table": True,
+            "is_temp": False,
+            "param": {
+                "schema": SCHEMA,
+                "table_name": test_utils.get_table_name("test_stats_check_1"),
             },
+        },
+    ],
+    indirect=True,
+)
+def test_truncate(sql_server, test_table, sample_dag):
+    sql_name, hook = sql_server
+    df = test_utils.get_dataframe_from_table(sql_name, test_table, hook)
+    assert df.count()[0] == 5
+    with sample_dag:
+        aql.truncate(
+            table=test_table,
         )
-        self.file_table = aql.load_file(
-            path=str(self.cwd) + "/../data/homes_merge_1.csv",
-            output_table=Table(
-                "truncate_test",
-                database="pagila",
-                conn_id="postgres_conn",
-                schema="public",
-            ),
-        ).operator.execute({"run_id": "foo"})
-        self.file_sqlite_table = aql.load_file(
-            path=str(self.cwd) + "/../data/homes_merge_1.csv",
-            output_table=Table(
-                "truncate_test",
-                conn_id="sqlite_conn",
-            ),
-        ).operator.execute({"run_id": "foo"})
+    test_utils.run_dag(sample_dag)
 
-    def test_truncate(self):
-        hook = PostgresHook(schema="pagila", postgres_conn_id="postgres_conn")
-        df = hook.get_pandas_df(sql="SELECT * FROM public.truncate_test")
-        assert df.count()[0] == 4
-        a = aql.truncate(
-            table=self.file_table,
-        )
-        a.execute({"run_id": "foo"})
-        df = hook.get_pandas_df(sql="SELECT * FROM public.truncate_test")
-        assert df.count()[0] == 0
-
-    def test_sqlite_truncate(self):
-        hook = SqliteHook(
-            sqlite_conn_id="sqlite_conn",
-        )
-        df = hook.get_pandas_df(sql="SELECT * FROM truncate_test")
-        assert df.count()[0] == 4
-        a = aql.truncate(
-            table=self.file_sqlite_table,
-        )
-        a.execute({"run_id": "foo"})
-        df = hook.get_pandas_df(sql="SELECT * FROM truncate_test")
-        assert df.count()[0] == 0
+    df = test_utils.get_dataframe_from_table(sql_name, test_table, hook)
+    assert df.count()[0] == 0


### PR DESCRIPTION
Closes: #307

Refactored test cases

- [x] Use test_tables fixture
- [x] Run operator for all supported databases
- [x] Run operator from within dag.