### PR TITLE
WIP: Refactor SqlDecorator.py

### DIFF
--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -2,12 +2,12 @@ from typing import Optional
 
 from airflow.utils.context import Context
 
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_unique_task_id
 
 
-class AgnosticAggregateCheck(SqlDecoratedOperator):
+class AgnosticAggregateCheck(SqlExecutor):
     template_fields = ("table",)
 
     def __init__(
@@ -53,19 +53,13 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
 
         task_id = get_unique_task_id("aggregate_check")
 
-        def null_function():
-            pass
-
         def handler_func(result):
             return result.fetchone()[0]
 
         super().__init__(
-            raw_sql=True,
             parameters={},
             task_id=task_id,
-            op_args=(),
             handler=handler_func,
-            python_callable=null_function,
             **kwargs,
         )
 

--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -6,7 +6,7 @@ from sqlalchemy import FLOAT, and_, cast, column, func, select, text
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.selectable import Select
 
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_unique_task_id
 
@@ -32,7 +32,7 @@ class Check:
         return value
 
 
-class AgnosticBooleanCheck(SqlDecoratedOperator):
+class AgnosticBooleanCheck(SqlExecutor):
     template_fields = ("table",)
 
     def __init__(
@@ -53,15 +53,9 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
         def handler_func(results):
             return results.fetchall()
 
-        def null_function() -> None:
-            pass
-
         super().__init__(
-            raw_sql=True,
             parameters={},
             task_id=task_id,
-            op_args=(),
-            python_callable=null_function,
             handler=handler_func,
             **kwargs,
         )

--- a/src/astro/sql/operators/agnostic_sql_append.py
+++ b/src/astro/sql/operators/agnostic_sql_append.py
@@ -6,18 +6,17 @@ from sqlalchemy.sql.elements import Cast, ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import Database
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table, TempTable
 from astro.utils.database import get_database_name
 from astro.utils.schema_util import (
     get_error_string_for_multiple_dbs,
     tables_from_same_db,
 )
-from astro.utils.table_handler import TableHandler
 from astro.utils.task_id_helper import get_unique_task_id
 
 
-class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
+class SqlAppendOperator(SqlExecutor):
     template_fields = ("main_table", "append_table")
 
     def __init__(
@@ -40,15 +39,9 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
         self.casted_columns = casted_columns
         task_id = get_unique_task_id("append_table")
 
-        def null_function():
-            pass
-
         super().__init__(
-            raw_sql=True,
             parameters={},
             task_id=kwargs.get("task_id") or task_id,
-            op_args=(),
-            python_callable=null_function,
             handler=lambda x: None,
             **kwargs,
         )

--- a/src/astro/sql/operators/agnostic_sql_merge.py
+++ b/src/astro/sql/operators/agnostic_sql_merge.py
@@ -54,7 +54,7 @@ class SqlMergeOperator(SqlExecutor):
                 get_error_string_for_multiple_dbs([self.target_table, self.merge_table])
             )
 
-        database = create_database_from_conn_id(self.conn_id)
+        database = create_database_from_conn_id(self.conn_id)  # type: ignore
         if database in (Database.POSTGRES, Database.POSTGRESQL):
             self.sql = postgres_merge_func(
                 target_table=self.target_table,

--- a/src/astro/sql/operators/agnostic_sql_merge.py
+++ b/src/astro/sql/operators/agnostic_sql_merge.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Union
 from airflow.exceptions import AirflowException
 
 from astro.constants import Database
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table, TempTable
 from astro.utils.bigquery_merge_func import bigquery_merge_func
 from astro.utils.database import create_database_from_conn_id
@@ -17,7 +17,7 @@ from astro.utils.sqlite_merge_func import sqlite_merge_func
 from astro.utils.task_id_helper import get_unique_task_id
 
 
-class SqlMergeOperator(SqlDecoratedOperator):
+class SqlMergeOperator(SqlExecutor):
     template_fields = ("target_table", "merge_table")
 
     def __init__(
@@ -38,15 +38,9 @@ class SqlMergeOperator(SqlDecoratedOperator):
         self.conflict_strategy = conflict_strategy
         task_id = get_unique_task_id("merge_table")
 
-        def null_function():
-            pass
-
         super().__init__(
-            raw_sql=True,
             parameters={},
             task_id=kwargs.get("task_id") or task_id,
-            op_args=(),
-            python_callable=null_function,
             **kwargs,
         )
 

--- a/src/astro/sql/operators/agnostic_sql_truncate.py
+++ b/src/astro/sql/operators/agnostic_sql_truncate.py
@@ -5,12 +5,12 @@ from sqlalchemy import MetaData
 from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import Database
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table
 from astro.utils.database import create_database_from_conn_id
 
 
-class SqlTruncateOperator(SqlDecoratedOperator):
+class SqlTruncateOperator(SqlExecutor):
     def __init__(
         self,
         table: Table,
@@ -21,16 +21,9 @@ class SqlTruncateOperator(SqlDecoratedOperator):
 
         task_id = get_unique_task_id(table.table_name + "_truncate")
 
-        def null_function(table: Table):
-            pass
-
         super().__init__(
-            raw_sql=True,
             parameters={},
             task_id=task_id,
-            op_args=(),
-            op_kwargs={"table": table},
-            python_callable=null_function,
             conn_id=self.table.conn_id,
             database=self.table.database,
             schema=self.table.schema,

--- a/src/astro/sql/operators/agnostic_stats_check.py
+++ b/src/astro/sql/operators/agnostic_stats_check.py
@@ -216,7 +216,7 @@ class AgnosticStatsCheck(SqlExecutor):
         )
 
     def execute(self, context: Dict):
-        database = create_database_from_conn_id(self.conn_id)
+        database = create_database_from_conn_id(self.conn_id)  # type: ignore
         check_handler = ChecksHandler(self.checks)
 
         valid_db = {

--- a/src/astro/sql/operators/agnostic_stats_check.py
+++ b/src/astro/sql/operators/agnostic_stats_check.py
@@ -4,7 +4,7 @@ from sqlalchemy import MetaData, case, func, or_, select
 from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import Database
-from astro.sql.operators.sql_decorator import SqlDecoratedOperator
+from astro.sql.operators.sql_decorator import SqlExecutor
 from astro.sql.table import Table
 from astro.utils.database import create_database_from_conn_id
 from astro.utils.schema_util import (
@@ -165,7 +165,7 @@ class ChecksHandler:
         return failed_checks_sql
 
 
-class AgnosticStatsCheck(SqlDecoratedOperator):
+class AgnosticStatsCheck(SqlExecutor):
     def __init__(
         self,
         checks: List[OutlierCheck],
@@ -201,23 +201,17 @@ class AgnosticStatsCheck(SqlDecoratedOperator):
                 get_error_string_for_multiple_dbs([main_table, compare_table])
             )
 
-        def null_function():
-            pass
-
         def handler_func(results):
             return results.fetchall()
 
         super().__init__(
-            raw_sql=True,
             parameters={},
             conn_id=main_table.conn_id,
             database=main_table.database,
             schema=main_table.schema,
             warehouse=main_table.warehouse,
             task_id=task_id,
-            op_args=(),
             handler=handler_func,
-            python_callable=null_function,
             **kwargs,
         )
 

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -119,7 +119,7 @@ class SqlExecutor(BaseOperator):
 
     def _add_templates_to_context(self, context):
         # candidate for database refactor
-        database = get_database_from_conn_id(self.conn_id)
+        database = create_database_from_conn_id(self.conn_id)
         if database in (Database.POSTGRES, Database.BIGQUERY):
             return postgres_transform.add_templates_to_context(self.parameters, context)
         elif database == Database.SNOWFLAKE:

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -2,7 +2,11 @@ import inspect
 from typing import Callable, Dict, Iterable, Mapping, Optional, Union
 
 import pandas as pd
-from airflow.decorators.base import DecoratedOperator, task_decorator_factory
+from airflow.decorators.base import (
+    BaseOperator,
+    DecoratedOperator,
+    task_decorator_factory,
+)
 from airflow.hooks.base import BaseHook
 from airflow.utils.db import provide_session
 from sqlalchemy.sql.functions import Function
@@ -21,6 +25,127 @@ from astro.utils.schema_util import create_schema_query, schema_exists
 from astro.utils.table_handler import TableHandler
 
 
+class SqlExecutor(BaseOperator):
+    def __init__(
+        self,
+        sql: Optional[str] = None,
+        conn_id: Optional[str] = None,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        role: Optional[str] = None,
+        warehouse: Optional[str] = None,
+        parameters: Optional[dict] = None,
+        handler: Optional[Callable] = None,
+        **kwargs,
+    ):
+        self.conn_id = conn_id
+        self.database = database
+        self.schema = schema
+        self.role = role
+        self.warehouse = warehouse
+        self.parameters = parameters
+        self.sql = sql
+        self.handler = handler
+        self.kwargs = kwargs or {}
+
+        if self.parameters is None:
+            self.parameters = {}
+
+        self.op_kwargs: Dict = self.kwargs.get("op_kwargs") or {}
+
+        super().__init__(
+            **kwargs,
+        )
+
+    @property
+    def hook(self):
+        return get_hook(
+            conn_id=self.conn_id,
+            database=self.database,
+            role=self.role,
+            schema=self.schema,
+            warehouse=self.warehouse,
+        )
+
+    @property
+    def conn_type(self):
+        return BaseHook.get_connection(self.conn_id).conn_type
+
+    def execute(self, context: Dict):
+        # handle templating
+        self.handle_params(context)
+
+        # update table name in context based on database
+        context = self._add_templates_to_context(context)
+
+        # render templating in sql query
+        if context:
+            self.sql = self.render_template(self.sql, context)
+
+        # update parameters for snowflake table with fully qualified names
+        self._process_params()
+
+        cursor = self._run_sql(self.sql, self.parameters)
+        if self.handler is not None:
+            return self.handler(cursor)
+        return cursor
+
+    def _run_sql(self, sql, parameters=None):
+        return run_sql(
+            engine=self.get_sql_alchemy_engine(),
+            sql_statement=sql,
+            parameters=parameters,
+        )
+
+    def get_sql_alchemy_engine(self):
+        return get_sqlalchemy_engine(self.hook)
+
+    # name can be improved.
+    # 1. method is merging op_kwargs and op_args into self.parameters
+    # 2. then self.parameters rendering templates in self.parameters
+    def handle_params(self, context):
+        if self.op_kwargs:
+            self.parameters.update(self.op_kwargs)  # type: ignore
+        # if self.op_args:
+        #     params = list(inspect.signature(self.python_callable).parameters.keys())
+        #     for i, arg in enumerate(self.op_args):
+        #         self.parameters[params[i]] = arg  # type: ignore
+        if context:
+            self.parameters = {
+                k: self.render_template(v, context) for k, v in self.parameters.items()  # type: ignore
+            }
+        # why are we overriding again??
+        self.parameters.update(self.op_kwargs)  # type: ignore
+
+    def _add_templates_to_context(self, context):
+        # candidate for database refactor
+        database = get_database_from_conn_id(self.conn_id)
+        if database in (Database.POSTGRES, Database.BIGQUERY):
+            return postgres_transform.add_templates_to_context(self.parameters, context)
+        elif database == Database.SNOWFLAKE:
+            return snowflake_transform.add_templates_to_context(
+                self.parameters, context
+            )
+        else:
+            return self.default_transform(self.parameters, context)
+
+    def default_transform(self, parameters, context):
+        for k, v in parameters.items():
+            if isinstance(v, Table):
+                context[k] = v.table_name
+            else:
+                # for sqla templating
+                context[k] = ":" + k
+        return context
+
+    # name can be improved.
+    def _process_params(self):
+        if self.conn_type == "snowflake":
+            self.parameters = snowflake_transform.process_params(
+                parameters=self.parameters
+            )
+
+
 class SqlDecoratedOperator(DecoratedOperator, TableHandler):
     def __init__(
         self,
@@ -36,21 +161,28 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         sql="",
         **kwargs,
     ):
+        # Init vars
         self.raw_sql = raw_sql
         self.autocommit = autocommit
         self.parameters = parameters
         self.handler = handler
         self.kwargs = kwargs or {}
         self.sql = sql
+
+        # optional args from op_kwargs
         self.op_kwargs: Dict = self.kwargs.get("op_kwargs") or {}
+
+        # get output table from op_kwargs
         if self.op_kwargs.get("output_table"):
             self.output_table: Optional[Table] = self.op_kwargs.pop("output_table")
         else:
             self.output_table = None
 
+        # handler function for processing resultProxy
         if self.op_kwargs.get("handler"):
             self.handler = self.op_kwargs.pop("handler")
 
+        # init db related params via op_kwargs
         self.conn_id = self.op_kwargs.pop("conn_id", conn_id)
         self.database = self.op_kwargs.pop("database", database)
         self.schema = self.op_kwargs.pop("schema", schema)
@@ -81,27 +213,40 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
 
     def execute(self, context: Dict):
 
+        # check for string/sqla based sql queries
         if not isinstance(self.sql, str):
             cursor = self._run_sql(self.sql, self.parameters)
             if self.handler is not None:
                 return self.handler(cursor)
             return cursor
 
+        # init db related vars
         self._set_variables_from_first_table()
         self.database = self.database or self.database_from_conn_id
 
+        # init db var - schema, user
         conn = BaseHook.get_connection(self.conn_id)
-
         self.schema = self.schema or SCHEMA
         self.user = conn.login
 
-        self.convert_op_arg_dataframes()
-        self.convert_op_kwarg_dataframes()
-        self.read_sql()
+        # place all the dataframe into sql table from op_kwargs/op_args
+        self.load_dataframes_from_op_args_to_sql_table()
+        self.load_dataframes_from_op_kwargs_to_sql_table()
+
+        # get sql query
+        self.get_sql_query_and_parameters()
+
+        # handle templating
         self.handle_params(context)
+
+        # update table name in context based on database
         context = self._add_templates_to_context(context)
+
+        # render templating in sql query
         if context:
             self.sql = self.render_template(self.sql, context)
+
+        # update parameters for snowflake table with fully qualified names
         self._process_params()
 
         output_table_name: str = ""
@@ -110,6 +255,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
 
         if not self.raw_sql:
 
+            # if the output table don't exist or is a tempTable
             if not self.output_table or type(self.output_table) == TempTable:
                 output_table_name = create_unique_table_name()
                 self._set_schema_if_needed(schema=SCHEMA)
@@ -124,9 +270,12 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
                     output_table_name, schema=self.output_table.schema
                 )
 
+            # drop existing table.
             self._run_sql(
                 f"DROP TABLE IF EXISTS {full_output_table_name};", self.parameters
             )
+            # create a new table.
+            # function name should be renamed to create_table_sql_statement.
             self.sql = self.create_temporary_table(self.sql, full_output_table_name)
         else:
             # If there's no SQL to run we simply return
@@ -141,11 +290,14 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
                 self.output_table = self.output_table.to_table(
                     table_name=output_table_name, schema=self.output_table.schema
                 )
+
             self.log.info("Returning table %s", self.output_table)
+            # misleading method name - populate_output_table_params()
             self.populate_output_table()
             return self.output_table
 
         elif self.raw_sql:
+            # process raw_sql with handler.
             if self.handler is not None:
                 return self.handler(query_result)
             return None
@@ -153,11 +305,14 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             self.output_table = Table(
                 table_name=output_table_name,
             )
+            # misleading method name - populate_output_table_params()
             self.populate_output_table()
             self.log.info("Returning table %s", self.output_table)
             return self.output_table
 
-    def read_sql(self):
+    def get_sql_query_and_parameters(self):
+        # option 1 - explicit pass sql queries/file path via self.sql param
+        # option 2 - get sql queries via python callable
         if self.sql == "":
             sql_stuff = self.python_callable(*self.op_args, **self.op_kwargs)
             # If we return two things, assume the second thing is the params
@@ -166,10 +321,13 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             else:
                 self.sql = sql_stuff
                 self.parameters = {}
-        elif self.sql[-4:] == ".sql":
+        elif self.sql.endswith(".sql"):
             with open(self.sql) as file:
                 self.sql = file.read().replace("\n", " ")
 
+    # name can be improved.
+    # 1. method is merging op_kwargs and op_args into self.parameters
+    # 2. then self.parameters rendering templates in self.parameters
     def handle_params(self, context):
         if self.op_kwargs:
             self.parameters.update(self.op_kwargs)  # type: ignore
@@ -181,8 +339,10 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             self.parameters = {
                 k: self.render_template(v, context) for k, v in self.parameters.items()  # type: ignore
             }
+        # why are we overriding again??
         self.parameters.update(self.op_kwargs)  # type: ignore
 
+    # why can't we handle this via get_qualified_name() function??
     def handle_output_table_schema(
         self, output_table_name: str, schema: Optional[str] = None
     ) -> str:
@@ -201,7 +361,9 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             output_table_name = self.database + "." + schema + "." + output_table_name
         return output_table_name
 
+    # name can be improved. - create_if_needed()
     def _set_schema_if_needed(self, schema=None):
+        # below line should use constants
         if schema is None:
             schema = self.schema
 
@@ -249,6 +411,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
                 query = query[:-1]
             return query
 
+        # handle this in get_qualified name of database
         if schema:
             output_table_name = f"{schema}.{output_table_name}"
 
@@ -269,6 +432,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         """
         pass
 
+    # name can be improved.
     def _process_params(self):
         if self.conn_type == "snowflake":
             self.parameters = snowflake_transform.process_params(
@@ -276,6 +440,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             )
 
     def _add_templates_to_context(self, context):
+        # candidate for database refactor
         database = create_database_from_conn_id(self.conn_id)
         if database in (Database.POSTGRES, Database.BIGQUERY):
             return postgres_transform.add_templates_to_context(self.parameters, context)
@@ -291,6 +456,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
             if isinstance(v, Table):
                 context[k] = v.table_name
             else:
+                # for sqla templating
                 context[k] = ":" + k
         return context
 
@@ -299,7 +465,8 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         # To-do
         pass
 
-    def convert_op_arg_dataframes(self):
+    # misleading name - should be load_dataframes_from_op_args_to_sql_table
+    def load_dataframes_from_op_args_to_sql_table(self):
         final_args = []
         for i, arg in enumerate(self.op_args):
             if type(arg) == pd.DataFrame:
@@ -324,7 +491,8 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
                 final_args.append(arg)
             self.op_args = tuple(final_args)
 
-    def convert_op_kwarg_dataframes(self):
+    # misleading name - should be load_dataframes_from_op_kwargs_to_sql_table
+    def load_dataframes_from_op_kwargs_to_sql_table(self):
         final_kwargs = {}
         for key, value in self.op_kwargs.items():
             if type(value) == pd.DataFrame:

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -20,6 +20,7 @@ from astro.utils.database import (
 )
 from astro.utils.load import load_dataframe_into_sql_table
 from astro.utils.schema_util import create_schema_query, schema_exists
+from astro.utils.table_handler import TableHandler
 
 
 class SqlExecutor(BaseOperator):
@@ -143,7 +144,7 @@ class SqlExecutor(BaseOperator):
             )
 
 
-class SqlDecoratedOperator(DecoratedOperator):
+class SqlDecoratedOperator(DecoratedOperator, TableHandler):
     def __init__(
         self,
         conn_id: Optional[str] = None,

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -5,6 +5,7 @@ from astro.utils.dependencies import postgres_sql
 
 
 def schema_exists(hook, schema, conn_type):
+    # why this is not happening for bigquery??
     if conn_type in ["postgresql", "postgres"]:
         created_schemas = hook.run(
             "SELECT schema_name FROM information_schema.schemata;",

--- a/src/astro/utils/table_handler.py
+++ b/src/astro/utils/table_handler.py
@@ -1,8 +1,6 @@
 import inspect
 from typing import Optional
 
-import pandas
-
 from astro.settings import SCHEMA
 from astro.sql.table import Table
 
@@ -19,52 +17,40 @@ class TableHandler:
         # where is op_args getting init from?
         # collect only tables in first_table and select the 1st one.
         if self.op_args:
-            table_index = [
-                x for x, t in enumerate(self.op_args) if isinstance(t, Table)
-            ]
-            conn_id_set = {x.conn_id for x in self.op_args if isinstance(x, Table)}
+            args_of_table_type = [arg for arg in self.op_args if isinstance(arg, Table)]
+
             # Check to see if all tables belong to same conn_id. Otherwise, we this can go wrong for cases
             # 1. When we have tables from different DBs.
             # 2. When we have tables from different conn_id, since they can be configured with different
             # database/schema etc.
-            if table_index and len(conn_id_set) == 1:
-                first_table = self.op_args[table_index[0]]
+            if (
+                len(args_of_table_type) == 1
+                or len({arg.conn_id for arg in args_of_table_type}) == 1
+            ):
+                first_table = args_of_table_type[0]
 
         if not first_table and self.op_kwargs and self.python_callable:
-            table_kwargs = [
-                x
-                for x in inspect.signature(self.python_callable).parameters.values()
-                if (
-                    x.annotation == Table
-                    and isinstance(self.op_kwargs[x.name], Table)
-                    or x.annotation == pandas.DataFrame
-                    and isinstance(self.op_kwargs[x.name], Table)
-                )
+            kwargs_of_table_type = [
+                self.op_kwargs[kwarg.name]
+                for kwarg in inspect.signature(self.python_callable).parameters.values()
+                if isinstance(self.op_kwargs[kwarg.name], Table)
             ]
-            conn_id_set = {
-                self.op_kwargs[x.name].conn_id
-                for x in inspect.signature(self.python_callable).parameters.values()
-                if (
-                    x.annotation == Table
-                    and isinstance(self.op_kwargs[x.name], Table)
-                    or x.annotation == pandas.DataFrame
-                    and isinstance(self.op_kwargs[x.name], Table)
-                )
-            }
-            if table_kwargs and len(conn_id_set) == 1:
-                first_table = self.op_kwargs[table_kwargs[0].name]
+            if (
+                len(kwargs_of_table_type) == 1
+                or len({kwarg.conn_id for kwarg in kwargs_of_table_type}) == 1
+            ):
+                first_table = kwargs_of_table_type[0]
 
         # If there is no first table via op_ags or kwargs, we check the parameters
         if not first_table and self.parameters:
-            if self.parameters:
-                param_tables = [
-                    t for t in self.parameters.values() if isinstance(t, Table)
-                ]
-                conn_id_set = {
-                    t.conn_id for t in self.parameters.values() if isinstance(t, Table)
-                }
-                if param_tables and len(conn_id_set) == 1:
-                    first_table = param_tables[0]
+            params_of_table_type = [
+                param for param in self.parameters.values() if isinstance(param, Table)
+            ]
+            if (
+                len(params_of_table_type) == 1
+                or len({param.conn_id for param in params_of_table_type}) == 1
+            ):
+                first_table = params_of_table_type[0]
 
         if first_table:
             self.conn_id = first_table.conn_id or self.conn_id

--- a/src/astro/utils/table_handler.py
+++ b/src/astro/utils/table_handler.py
@@ -15,6 +15,9 @@ class TableHandler:
         to create default values.
         """
         first_table: Optional[Table] = None
+
+        # where is op_args getting init from?
+        # collect only tables in first_table and select the 1st one.
         if self.op_args:
             table_index = [
                 x for x, t in enumerate(self.op_args) if isinstance(t, Table)
@@ -70,6 +73,7 @@ class TableHandler:
             self.warehouse = first_table.warehouse or self.warehouse
             self.role = first_table.role or self.role
 
+    # method needs to renamed - populate_output_table_params()
     def populate_output_table(self):
         self.output_table.conn_id = self.output_table.conn_id or self.conn_id
         self.output_table.database = self.output_table.database or self.database


### PR DESCRIPTION
Related: #279

As a part of our refactoring, we should create a class that only handles SQL execution that does not require any logic for a python decorator. This will make it easier to subclass SQL functions that are not decorators in the future.

Acceptance criteria:

- [ ] All tests should pass and there should be no change in top level functionality
- [ ] There should be a SQLExcecutor class that can execute SQL with schema handling but does not require a decorator
- [ ] The SQLDecorator class should be able to use the SQLExecutor class to reduce code duplicaiton.