### PR TITLE
Fix #329 check if schema exists before creating it

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -172,6 +172,23 @@ def sql_server(request):
 
 
 @pytest.fixture
+def schema_fixture(request, sql_server):
+    """
+    Given request.param in the format:
+        "someschema"  # name of the schema to be created
+
+    If the schema exists, it is deleted during the tests setup and tear down.
+    """
+    schema_name = request.param
+    _, hook = sql_server
+
+    hook.run(f"DROP SCHEMA IF EXISTS {schema_name}")
+    yield
+
+    hook.run(f"DROP SCHEMA IF EXISTS {schema_name}")
+
+
+@pytest.fixture
 def database_table_fixture(request):
     """
     Given request.param in the format:

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -106,11 +106,13 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
 
         output_table_name: str = ""
 
+        self._set_schema_if_needed()
+
         if not self.raw_sql:
-            self._set_schema_if_needed()
 
             if not self.output_table or type(self.output_table) == TempTable:
                 output_table_name = create_unique_table_name()
+                self._set_schema_if_needed(schema=SCHEMA)
                 full_output_table_name = self.handle_output_table_schema(
                     # Since there is no output table defined we have to assume default schema
                     output_table_name,

--- a/src/astro/sql/operators/sql_decorator.py
+++ b/src/astro/sql/operators/sql_decorator.py
@@ -5,7 +5,6 @@ import pandas as pd
 from airflow.decorators.base import DecoratedOperator, task_decorator_factory
 from airflow.hooks.base import BaseHook
 from airflow.utils.db import provide_session
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql.functions import Function
 
 from astro.constants import Database
@@ -81,6 +80,7 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         )
 
     def execute(self, context: Dict):
+
         if not isinstance(self.sql, str):
             cursor = self._run_sql(self.sql, self.parameters)
             if self.handler is not None:
@@ -105,15 +105,9 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         self._process_params()
 
         output_table_name: str = ""
-        # Create DEFAULT SCHEMA if not created.
-        self._set_schema_if_needed(SCHEMA)
 
         if not self.raw_sql:
-            # Create a table name for the temp table
-            if not schema_exists(
-                hook=self.hook, schema=self.schema, conn_type=self.conn_type
-            ):
-                self._set_schema_if_needed()
+            self._set_schema_if_needed()
 
             if not self.output_table or type(self.output_table) == TempTable:
                 output_table_name = create_unique_table_name()
@@ -206,17 +200,26 @@ class SqlDecoratedOperator(DecoratedOperator, TableHandler):
         return output_table_name
 
     def _set_schema_if_needed(self, schema=None):
-        if self.conn_type in ["postgres", "snowflake", "bigquery"]:
+        if schema is None:
+            schema = self.schema
+
+        database_expects_schema = self.conn_type in [
+            "postgres",
+            "snowflake",
+            "bigquery",
+        ]
+        schema_exist_ = schema_exists(
+            hook=self.hook, schema=schema, conn_type=self.conn_type
+        )
+
+        if database_expects_schema and not schema_exist_:
             schema_statement = create_schema_query(
                 conn_type=self.conn_type,
                 hook=self.hook,
-                schema_id=schema if schema else self.schema,
+                schema_id=schema,
                 user=self.user,
             )
-            try:
-                self._run_sql(schema_statement, {})
-            except ProgrammingError as e:
-                print(e)
+            self._run_sql(schema_statement, {})
 
     def get_sql_alchemy_engine(self):
         return get_sqlalchemy_engine(self.hook)

--- a/tests/operators/test_sql_decorator.py
+++ b/tests/operators/test_sql_decorator.py
@@ -58,3 +58,101 @@ def test_sql_decorator_basic_functionality(sample_dag, sql_server, test_table):
             sql=f"SELECT list FROM {test_table.qualified_name()} WHERE sell=232",
         )
     test_utils.run_dag(sample_dag)
+
+
+@pytest.mark.parametrize(
+    "sql_server",
+    [
+        "snowflake",
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "test_table",
+    [
+        {
+            "path": str(CWD) + "/../data/sample.csv",
+            "load_table": True,
+            "is_temp": False,
+            "param": {
+                "schema": SCHEMA,
+                "table_name": test_utils.get_table_name("test"),
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_sql_decorator_does_not_create_schema_when_the_schema_exists(
+    sample_dag, sql_server, test_table
+):
+    """Test basic sql execution of SqlDecoratedOperator."""
+    _, hook = sql_server
+
+    sql_statement = f"SELECT * FROM {test_table.qualified_name()} WHERE id=4"
+    df = hook.get_pandas_df(sql_statement)
+    assert df.empty
+
+    with sample_dag:
+        SqlDecoratedOperator(
+            raw_sql=True,
+            parameters={},
+            task_id="SomeTask",
+            op_args=(),
+            conn_id=test_table.conn_id,
+            database=test_table.database,
+            python_callable=lambda: None,
+            sql=f"INSERT INTO {test_table.qualified_name()} (id, name) VALUES (4, 'New Person');",
+        )
+    test_utils.run_dag(sample_dag)
+
+    df = hook.get_pandas_df(sql_statement)
+    assert df.to_dict("r") == [{"ID": 4, "NAME": "New Person"}]
+
+
+@pytest.mark.parametrize(
+    "sql_server",
+    [
+        "postgres",
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "test_table",
+    [
+        {
+            "path": str(CWD) + "/../data/sample.csv",
+            "load_table": True,
+            "is_temp": False,
+            "param": {
+                "schema": "some_new_schema",
+                "table_name": test_utils.get_table_name("test"),
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_sql_decorator_creates_schema_when_it_does_not_exist(
+    sample_dag, sql_server, test_table
+):
+    """Test basic sql execution of SqlDecoratedOperator."""
+    _, hook = sql_server
+
+    sql_statement = f"SELECT * FROM {test_table.qualified_name()} WHERE id=4"
+    df = hook.get_pandas_df(sql_statement)
+    assert df.empty
+
+    with sample_dag:
+        SqlDecoratedOperator(
+            raw_sql=True,
+            parameters={},
+            task_id="SomeTask",
+            op_args=(),
+            conn_id=test_table.conn_id,
+            database=test_table.database,
+            python_callable=lambda: None,
+            sql=f"INSERT INTO {test_table.qualified_name()} (id, name) VALUES (4, 'New Person');",
+        )
+    test_utils.run_dag(sample_dag)
+
+    df = hook.get_pandas_df(sql_statement)
+    assert df.to_dict("r") == [{"id": 4, "name": "New Person"}]


### PR DESCRIPTION
Not all users have permission to create a schema.
The Astro Python SDK should only attempt to create a schema if it does not exist.
Fixes: #329 