### PR TITLE
Relaced astro.sql.table with astro.sql.tables.

### DIFF
--- a/example_dags/example_amazon_s3_postgres.py
+++ b/example_dags/example_amazon_s3_postgres.py
@@ -6,7 +6,7 @@ from pandas import DataFrame
 
 from astro import sql as aql
 from astro.dataframe import dataframe as df
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Metadata, Table
 
 s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
@@ -38,8 +38,8 @@ def my_df_func(input_df: DataFrame):
 with dag:
     my_homes_table = aql.load_file(
         path=f"{s3_bucket}/homes.csv",
-        output_table=TempTable(
-            database="pagila",
+        output_table=Table(
+            metadata=Metadata(database="pagila"),
             conn_id="postgres_conn",
         ),
     )

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -5,7 +5,7 @@ from airflow.utils import timezone
 
 # Import Operator
 import astro.sql as aql
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 
 default_args = {
     "owner": "airflow",
@@ -26,7 +26,9 @@ def example_amazon_s3_postgres_load_and_save():
         path=f"{s3_bucket}/homes.csv",
         file_conn_id="",
         output_table=Table(
-            "expected_table_from_s3", conn_id="postgres_conn", database="postgres"
+            name="expected_table_from_s3",
+            conn_id="postgres_conn",
+            metadata=Metadata(database="postgres"),
         ),
     )
 

--- a/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/example_dags/example_amazon_s3_snowflake_transform.py
@@ -9,7 +9,7 @@ from airflow.decorators import dag
 
 from astro import dataframe as df
 from astro import sql as aql
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 
 
 @aql.transform()
@@ -50,16 +50,20 @@ def example_amazon_s3_snowflake_transform():
     s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
     input_table_1 = Table(
-        "ADOPTION_CENTER_1",
-        database=os.environ["SNOWFLAKE_DATABASE"],
-        schema=os.environ["SNOWFLAKE_SCHEMA"],
+        name="ADOPTION_CENTER_1",
         conn_id="snowflake_conn",
+        metadata=Metadata(
+            database=os.environ["SNOWFLAKE_DATABASE"],
+            schema=os.environ["SNOWFLAKE_SCHEMA"],
+        ),
     )
     input_table_2 = Table(
-        "ADOPTION_CENTER_2",
-        database=os.environ["SNOWFLAKE_DATABASE"],
-        schema=os.environ["SNOWFLAKE_SCHEMA"],
+        name="ADOPTION_CENTER_2",
         conn_id="snowflake_conn",
+        metadata=Metadata(
+            database=os.environ["SNOWFLAKE_DATABASE"],
+            schema=os.environ["SNOWFLAKE_SCHEMA"],
+        ),
     )
 
     temp_table_1 = aql.load_file(
@@ -82,9 +86,9 @@ def example_amazon_s3_snowflake_transform():
     aggregate_data(
         cleaned_data,
         output_table=Table(
-            "aggregated_adoptions_" + str(int(time.time())),
-            schema=os.environ["SNOWFLAKE_SCHEMA"],
+            name="aggregated_adoptions_" + str(int(time.time())),
             conn_id="snowflake_conn",
+            metadata=Metadata(schema=os.environ["SNOWFLAKE_SCHEMA"]),
         ),
     )
 

--- a/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -20,7 +20,7 @@ from airflow.utils import timezone
 
 import astro.sql as aql
 from astro import dataframe
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 
 gcs_bucket = os.getenv("GCS_BUCKET", "gs://dag-authoring")
 
@@ -32,7 +32,9 @@ with DAG(
     t1 = aql.load_file(
         task_id="load_from_github_to_bq",
         path="https://raw.githubusercontent.com/astro-projects/astro/main/tests/data/imdb.csv",
-        output_table=Table("imdb_movies", conn_id="bigquery", schema="astro"),
+        output_table=Table(
+            name="imdb_movies", conn_id="bigquery", metadata=Metadata(schema="astro")
+        ),
     )
 
     # Setting "identifiers_as_lower" to True will lowercase all column names

--- a/example_dags/example_snowflake_render.py
+++ b/example_dags/example_snowflake_render.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from airflow.models import DAG, Param
 
 from astro.sql import load_file, render
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 
 SNOWFLAKE_CONN_ID = "snowflake_conn"
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -40,9 +40,11 @@ with dag:
         path=FILE_PATH + "homes.csv",
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
-            database=os.getenv("SNOWFLAKE_DATABASE"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-            schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            metadata=Metadata(
+                database=os.getenv("SNOWFLAKE_DATABASE"),
+                warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            ),
         ),
     )
 
@@ -50,9 +52,11 @@ with dag:
         path=FILE_PATH + "homes2.csv",
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
-            database=os.getenv("SNOWFLAKE_DATABASE"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-            schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            metadata=Metadata(
+                database=os.getenv("SNOWFLAKE_DATABASE"),
+                warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            ),
         ),
     )
 

--- a/example_dags/example_sqlite_load_transform.py
+++ b/example_dags/example_sqlite_load_transform.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from airflow import DAG
 
 from astro import sql as aql
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -30,13 +30,17 @@ with DAG(
         path="https://raw.githubusercontent.com/astro-projects/astro/main/tests/data/imdb.csv",
         task_id="load_csv",
         output_table=Table(
-            table_name="imdb_movies", database="sqlite", conn_id="sqlite_default"
+            name="imdb_movies",
+            conn_id="sqlite_default",
+            metadata=Metadata(database="sqlite"),
         ),
     )
 
     top_five_animations(
         input_table=imdb_movies,
         output_table=Table(
-            table_name="top_animation", database="sqlite", conn_id="sqlite_default"
+            name="top_animation",
+            conn_id="sqlite_default",
+            metadata=Metadata(database="sqlite"),
         ),
     )

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -16,7 +16,7 @@ from astro.sql.operators.sql_decorator import (  # noqa: F401
     transform_decorator,
 )
 from astro.sql.parsers.sql_directory_parser import render  # noqa: F401
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 
 def transform(

--- a/src/astro/sql/operators/agnostic_aggregate_check.py
+++ b/src/astro/sql/operators/agnostic_aggregate_check.py
@@ -3,7 +3,7 @@ from typing import Optional
 from airflow.utils.context import Context
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from astro.utils.task_id_helper import get_unique_task_id
 
 
@@ -71,7 +71,7 @@ class AgnosticAggregateCheck(SqlDecoratedOperator):
 
     def execute(self, context: Context) -> Table:
         self.conn_id = self.table.conn_id
-        self.database = self.table.database
+        self.database = getattr(self.table.metadata, "database", None)
         self.sql = self.check
         self.parameters = {"table": self.table}
 

--- a/src/astro/sql/operators/agnostic_load_file.py
+++ b/src/astro/sql/operators/agnostic_load_file.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator
@@ -6,7 +6,7 @@ from airflow.models.xcom_arg import XComArg
 
 from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.files import get_files
-from astro.sql.table import Table, TempTable, create_table_name
+from astro.sql.tables import Table
 from astro.utils import get_hook
 from astro.utils.database import create_database_from_conn_id
 from astro.utils.load import load_dataframe_into_sql_table, populate_normalize_config
@@ -32,7 +32,7 @@ class AgnosticLoadFile(BaseOperator):
     def __init__(
         self,
         path: str,
-        output_table: Union[TempTable, Table],
+        output_table: Table,
         file_conn_id: Optional[str] = "",
         chunksize: int = DEFAULT_CHUNK_SIZE,
         if_exists: str = "replace",
@@ -40,7 +40,7 @@ class AgnosticLoadFile(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.output_table: Union[TempTable, Table] = output_table
+        self.output_table: Table = output_table
         self.path = path
         self.chunksize = chunksize
         self.file_conn_id = file_conn_id
@@ -49,7 +49,7 @@ class AgnosticLoadFile(BaseOperator):
         self.ndjson_normalize_sep = ndjson_normalize_sep
         self.normalize_config: Dict[str, str] = {}
 
-    def execute(self, context: Any) -> Union[TempTable, Table]:
+    def execute(self, context: Any) -> Table:
         """
         Load an existing dataset from a supported file into a SQL table.
         """
@@ -63,17 +63,17 @@ class AgnosticLoadFile(BaseOperator):
 
         hook = get_hook(
             conn_id=self.output_table.conn_id,
-            database=self.output_table.database,
-            schema=self.output_table.schema,
-            warehouse=self.output_table.warehouse,
+            database=getattr(self.output_table.metadata, "database", None),
+            schema=getattr(self.output_table.metadata, "schema", None),
+            warehouse=getattr(self.output_table.metadata, "warehouse", None),
         )
 
-        self._configure_output_table(context)
+        # self._configure_output_table(context)
         return self.load_data(hook=hook, path=self.path, file_conn_id=self.file_conn_id)
 
     def load_data(
         self, path: str, hook: BaseHook, file_conn_id: Optional[str] = None
-    ) -> Union[TempTable, Table]:
+    ) -> Table:
         """Loads csv/parquet table from local/S3/GCS with Pandas.
         Infers SQL database type based on connection then loads table to db.
         """
@@ -96,19 +96,19 @@ class AgnosticLoadFile(BaseOperator):
 
         return self.output_table
 
-    def _configure_output_table(self, context: Any) -> None:
-        # TODO: Move this function to the SQLDecorator, so it can be reused across operators
-        if isinstance(self.output_table, TempTable):
-            self.output_table = self.output_table.to_table(
-                create_table_name(context=context)
-            )
-        if not self.output_table.table_name:
-            self.output_table.table_name = create_table_name(context=context)
+    # def _configure_output_table(self, context: Any) -> None:
+    #     # TODO: Move this function to the SQLDecorator, so it can be reused across operators
+    #     # if isinstance(self.output_table, TempTable):
+    #     #     self.output_table = self.output_table.to_table(
+    #     #         create_table_name(context=context)
+    #     #     )
+    #     # if not self.output_table.table_name:
+    #     #     self.output_table.table_name = create_table_name(context=context)
 
 
 def load_file(
     path: str,
-    output_table: Union[TempTable, Table],
+    output_table: Table,
     file_conn_id: Optional[str] = "",
     task_id: Optional[str] = None,
     if_exists: str = "replace",

--- a/src/astro/sql/operators/agnostic_sql_append.py
+++ b/src/astro/sql/operators/agnostic_sql_append.py
@@ -6,8 +6,9 @@ from sqlalchemy.sql.elements import Cast, ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import Database
+from astro.databases import create_database
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Table
 from astro.utils.database import get_database_name
 from astro.utils.schema_util import (
     get_error_string_for_multiple_dbs,
@@ -22,8 +23,8 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
 
     def __init__(
         self,
-        append_table: Union[Table, TempTable],
-        main_table: Union[Table, TempTable],
+        append_table: Table,
+        main_table: Table,
         columns: Optional[List[str]] = None,
         casted_columns: Optional[dict] = None,
         **kwargs,
@@ -53,7 +54,7 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
             **kwargs,
         )
 
-    def execute(self, context: dict) -> Union[Table, TempTable]:
+    def execute(self, context: dict) -> Table:
         if not tables_from_same_db([self.append_table, self.main_table]):
             raise ValueError(
                 get_error_string_for_multiple_dbs([self.append_table, self.main_table])
@@ -61,9 +62,15 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
 
         self.main_table.conn_id = self.main_table.conn_id or self.append_table.conn_id
         self.conn_id = self.main_table.conn_id or self.append_table.conn_id
-        self.database = self.main_table.database or self.append_table.database
-        self.warehouse = self.main_table.warehouse or self.append_table.warehouse
-        self.schema = self.main_table.schema or self.append_table.schema
+        self.database = getattr(self.main_table, "database", None) or getattr(
+            self.append_table, "database", None
+        )
+        self.warehouse = getattr(self.main_table, "warehouse", None) or getattr(
+            self.append_table, "warehouse", None
+        )
+        self.schema = getattr(self.main_table, "schema", None) or getattr(
+            self.append_table, "schema", None
+        )
         self.sql = self.append(
             main_table=self.main_table,
             append_table=self.append_table,
@@ -75,10 +82,10 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
 
     def append(
         self,
-        main_table: Union[Table, TempTable],
+        main_table: Table,
         columns: List[str],
         casted_columns: dict,
-        append_table: Union[Table, TempTable],
+        append_table: Table,
     ):
         engine = self.get_sql_alchemy_engine()
         if self.schema and get_database_name(engine) != Database.SQLITE:
@@ -86,11 +93,12 @@ class SqlAppendOperator(SqlDecoratedOperator, TableHandler):
         else:
             metadata = MetaData()
         # TO Do - fix bigquery and postgres reflection table issue.
+        db = create_database(main_table.conn_id)
         main_table_sqla = SqlaTable(
-            main_table.table_name, metadata, autoload_with=engine
+            db.get_table_qualified_name(main_table), metadata, autoload_with=engine
         )
         append_table_sqla = SqlaTable(
-            append_table.table_name, metadata, autoload_with=engine
+            db.get_table_qualified_name(append_table), metadata, autoload_with=engine
         )
 
         column_names: List[Union[ColumnClause, Cast]] = [column(c) for c in columns]

--- a/src/astro/sql/operators/agnostic_stats_check.py
+++ b/src/astro/sql/operators/agnostic_stats_check.py
@@ -5,7 +5,7 @@ from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import Database
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from astro.utils.database import create_database_from_conn_id
 from astro.utils.schema_util import (
     get_error_string_for_multiple_dbs,
@@ -97,11 +97,9 @@ class ChecksHandler:
     def prepare_comparison_sql(
         self, main_table: Table, compare_table: Table, engine, metadata_obj
     ):
-        main_table_sqla = SqlaTable(
-            main_table.table_name, metadata_obj, autoload_with=engine
-        )
+        main_table_sqla = SqlaTable(main_table.name, metadata_obj, autoload_with=engine)
         compare_table_sqla = SqlaTable(
-            compare_table.table_name, metadata_obj, autoload_with=engine
+            compare_table.name, metadata_obj, autoload_with=engine
         )
 
         main_table_stats_sql = self.prepare_main_stats_sql(main_table, main_table_sqla)
@@ -139,11 +137,9 @@ class ChecksHandler:
         engine,
         metadata_obj,
     ):
-        main_table_sqla = SqlaTable(
-            main_table.table_name, metadata_obj, autoload_with=engine
-        )
+        main_table_sqla = SqlaTable(main_table.name, metadata_obj, autoload_with=engine)
         compare_table_sqla = SqlaTable(
-            compare_table.table_name, metadata_obj, autoload_with=engine
+            compare_table.name, metadata_obj, autoload_with=engine
         )
 
         main_stats = self.prepare_main_stats_sql(main_table, main_table_sqla)
@@ -192,9 +188,9 @@ class AgnosticStatsCheck(SqlDecoratedOperator):
         self.max_rows_returned = max_rows_returned
         self.conn_id = main_table.conn_id
         self.checks = checks
-        self.database = main_table.database
+        self.database = getattr(main_table.metadata, "database", None)
 
-        task_id = main_table.table_name + "_" + "stats_check"
+        task_id = main_table.name + "_" + "stats_check"
 
         if not tables_from_same_db([main_table, compare_table]):
             raise ValueError(
@@ -211,9 +207,9 @@ class AgnosticStatsCheck(SqlDecoratedOperator):
             raw_sql=True,
             parameters={},
             conn_id=main_table.conn_id,
-            database=main_table.database,
-            schema=main_table.schema,
-            warehouse=main_table.warehouse,
+            database=getattr(main_table.metadata, "database", None),
+            schema=getattr(main_table.metadata, "schema", None),
+            warehouse=getattr(main_table.metadata, "warehouse", None),
             task_id=task_id,
             op_args=(),
             handler=handler_func,
@@ -235,7 +231,9 @@ class AgnosticStatsCheck(SqlDecoratedOperator):
 
         metadata_params = {}
         if database.value in valid_db:
-            metadata_params = {"schema": self.main_table.schema}
+            metadata_params = {
+                "schema": getattr(self.main_table.metadata, "schema", None)
+            }
         metadata = MetaData(**metadata_params)
 
         self.sql = check_handler.prepare_comparison_sql(

--- a/src/astro/sql/parsers/sql_directory_parser.py
+++ b/src/astro/sql/parsers/sql_directory_parser.py
@@ -11,7 +11,7 @@ from airflow.models.dag import DagContext
 from airflow.models.xcom_arg import XComArg
 
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Table
 
 
 def get_paths_for_render(path):
@@ -81,10 +81,7 @@ def render_single_path(
             }
             if front_matter_opts.get("output_table"):
                 out_table_dict = front_matter_opts.pop("output_table")
-                if out_table_dict.get("table_name"):
-                    op_kwargs = {"output_table": Table(**out_table_dict)}
-                else:
-                    op_kwargs = {"output_table": TempTable(**out_table_dict)}
+                op_kwargs = {"output_table": Table(**out_table_dict)}
             operator_kwargs = set_kwargs_with_defaults(
                 front_matter_opts, conn_id, database, role, schema, warehouse
             )

--- a/src/astro/utils/bigquery_merge_func.py
+++ b/src/astro/utils/bigquery_merge_func.py
@@ -1,4 +1,5 @@
-from astro.sql.table import Table
+from astro.databases import create_database
+from astro.sql.tables import Table
 
 
 def bigquery_merge_func(
@@ -9,7 +10,8 @@ def bigquery_merge_func(
     merge_columns,
     conflict_strategy,
 ):
-    statement = f"MERGE {target_table.qualified_name()} T USING {merge_table.qualified_name()} S\
+    db = create_database(target_table.conn_id)
+    statement = f"MERGE {db.get_table_qualified_name(target_table)} T USING {db.get_table_qualified_name(merge_table)} S\
                 ON {' AND '.join(['T.' + col + '= S.' + col for col in merge_keys])}\
                 WHEN NOT MATCHED BY TARGET THEN INSERT ({','.join(target_columns)}) VALUES ({','.join(merge_columns)})"
 

--- a/src/astro/utils/delete.py
+++ b/src/astro/utils/delete.py
@@ -1,16 +1,15 @@
-from typing import Union
-
 import pandas as pd
 from airflow.hooks.base import BaseHook
 
-from astro.sql.table import Table, TempTable, create_unique_table_name
+from astro.databases import create_database
+from astro.sql.tables import Metadata, Table
 from astro.utils.database import get_sqlalchemy_engine, run_sql
 from astro.utils.load import load_dataframe_into_sql_table
 
 
 def delete_dataframe_rows_from_table(
     pandas_dataframe: pd.DataFrame,
-    target_table: Union[Table, TempTable],
+    target_table: Table,
     hook: BaseHook,
 ):
     """
@@ -24,22 +23,26 @@ def delete_dataframe_rows_from_table(
     :type hook: Airflow Hook to the target database
     """
     # First we create a temporary table using the dataframe values
-    tmp_table = TempTable(
+    tmp_table = Table(
         conn_id=target_table.conn_id,
-        database=target_table.database,
-        warehouse=target_table.warehouse,
-        role=target_table.role,
+        metadata=Metadata(
+            database=getattr(target_table.metadata, "database", None),
+            warehouse=getattr(target_table.metadata, "warehouse", None),
+            role=getattr(target_table.metadata, "role", None),
+        ),
     )
-    tmp_table_name = create_unique_table_name()
-    named_table = tmp_table.to_table(tmp_table_name)
-    load_dataframe_into_sql_table(pandas_dataframe, named_table, hook)
+    # tmp_table_name = create_unique_table_name()
+    # named_table = tmp_table.to_table(tmp_table_name)
+    load_dataframe_into_sql_table(pandas_dataframe, tmp_table, hook)
 
     # Then we remove the (dataframe) temporary table values from the target table
     engine = get_sqlalchemy_engine(hook)
+    db = create_database(target_table.conn_id)
     run_sql(
         engine,
-        f"DELETE FROM {target_table.qualified_name()} WHERE Id IN (SELECT Id FROM {named_table.qualified_name()})",
+        f"DELETE FROM {db.get_table_qualified_name(target_table)} "
+        f"WHERE Id IN (SELECT Id FROM {db.get_table_qualified_name(tmp_table)})",
     )
 
     # Finally, we delete the temporary table which had the dataframe values
-    run_sql(engine, f"DROP TABLE {named_table.qualified_name()}")
+    run_sql(engine, f"DROP TABLE {db.get_table_qualified_name(tmp_table)}")

--- a/src/astro/utils/load.py
+++ b/src/astro/utils/load.py
@@ -21,7 +21,7 @@ from astro.constants import (
     Database,
     FileType,
 )
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from astro.utils.database import get_database_name, get_sqlalchemy_engine
 from astro.utils.dependencies import pandas_tools
 from astro.utils.file import get_filetype, get_size
@@ -234,8 +234,8 @@ def load_dataframe_into_sql_table(
     database = get_database_name(hook)
     engine = get_sqlalchemy_engine(hook)
 
-    output_table_name = output_table.table_name
-    schema = output_table.schema
+    output_table_name = output_table.name
+    schema = getattr(output_table.metadata, "schema", None)
     conn = hook.get_connection(output_table.conn_id)
     user = conn.login
 

--- a/src/astro/utils/postgres_merge_func.py
+++ b/src/astro/utils/postgres_merge_func.py
@@ -1,4 +1,5 @@
-from astro.sql.table import Table
+from astro.databases import create_database
+from astro.sql.tables import Table
 from astro.utils.dependencies import PostgresHook, postgres_sql
 
 
@@ -24,11 +25,13 @@ def postgres_merge_func(
         postgres_sql.SQL("{x}=EXCLUDED.{y}").format(x=x, y=y) for x, y in column_pairs
     ]
 
+    db = create_database(merge_table.conn_id)
+
     query = postgres_sql.SQL(statement).format(
         target_columns=postgres_sql.SQL(",").join(target_column_names),
-        main_table=postgres_sql.Identifier(*target_table.identifier_args()),
+        main_table=postgres_sql.Identifier(*db.get_table_qualified_name(target_table)),
         append_columns=postgres_sql.SQL(",").join(append_column_names),
-        append_table=postgres_sql.Identifier(*merge_table.identifier_args()),
+        append_table=postgres_sql.Identifier(*db.get_table_qualified_name(merge_table)),
         update_statements=postgres_sql.SQL(",").join(update_statements),
         merge_keys=postgres_sql.SQL(",").join(
             [postgres_sql.Identifier(x) for x in merge_keys]

--- a/src/astro/utils/postgres_transform.py
+++ b/src/astro/utils/postgres_transform.py
@@ -1,10 +1,12 @@
-from astro.sql.table import Table
+from astro.databases import create_database
+from astro.sql.tables import Table
 
 
 def add_templates_to_context(parameters, context):
     for k, v in parameters.items():
         if isinstance(v, Table):
-            context[k] = v.qualified_name()
+            db = create_database(v.conn_id)
+            context[k] = db.get_table_qualified_name(v)
         else:
             context[k] = ":" + k
     return context

--- a/src/astro/utils/schema_util.py
+++ b/src/astro/utils/schema_util.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from astro.utils.dependencies import postgres_sql
 
 
@@ -55,4 +55,4 @@ def get_error_string_for_multiple_dbs(tables: List[Table]):
     :param tables: list of table
     :return: String: error string
     """
-    return f'Tables should belong to same db {", ".join([f"{table.table_name}: {table.conn_id}" for table in tables])}'
+    return f'Tables should belong to same db {", ".join([f"{table.name}: {table.conn_id}" for table in tables])}'

--- a/src/astro/utils/snowflake_merge_func.py
+++ b/src/astro/utils/snowflake_merge_func.py
@@ -1,6 +1,6 @@
 from airflow.exceptions import AirflowException
 
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 
 def wrap_identifier(inp):
@@ -18,17 +18,17 @@ def snowflake_merge_func(
     statement = "merge into {{main_table}} using {{merge_table}} on " "{merge_clauses}"
 
     merge_target_dict = {
-        "merge_clause_target_" + str(i): target_table.table_name + "." + x
+        "merge_clause_target_" + str(i): target_table.name + "." + x
         for i, x in enumerate(merge_keys.keys())
     }
     merge_append_dict = {
-        "merge_clause_append_" + str(i): merge_table.table_name + "." + x
+        "merge_clause_append_" + str(i): merge_table.name + "." + x
         for i, x in enumerate(merge_keys.values())
     }
 
     statement = fill_in_merge_clauses(merge_append_dict, merge_target_dict, statement)
 
-    values_to_check = [target_table.table_name, merge_table.table_name]
+    values_to_check = [target_table.name, merge_table.name]
     values_to_check.extend(target_columns)
     values_to_check.extend(merge_columns)
     for v in values_to_check:
@@ -41,8 +41,8 @@ def snowflake_merge_func(
         statement += " when matched then UPDATE SET {merge_vals}"
         statement = fill_in_update_statement(
             statement,
-            target_table.table_name,
-            merge_table.table_name,
+            target_table.name,
+            merge_table.name,
             target_columns,
             merge_columns,
         )
@@ -50,8 +50,8 @@ def snowflake_merge_func(
         " when not matched then insert({target_columns}) values ({append_columns})"
     )
     statement = fill_in_append_statements(
-        target_table.table_name,
-        merge_table.table_name,
+        target_table.name,
+        merge_table.name,
         statement,
         target_columns,
         merge_columns,
@@ -70,12 +70,12 @@ def fill_in_append_statements(
     main_table,
     merge_table,
     statement,
-    targest_columns,
+    target_columns,
     merge_columns,
 ):
     statement = statement.replace(
         "{target_columns}",
-        ",".join(f"{main_table}.{t}" for t in targest_columns),
+        ",".join(f"{main_table}.{t}" for t in target_columns),
     )
     statement = statement.replace(
         "{append_columns}",

--- a/src/astro/utils/snowflake_transform.py
+++ b/src/astro/utils/snowflake_transform.py
@@ -1,5 +1,5 @@
 from astro.settings import SCHEMA
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 
 def _handle_table(t: Table):
@@ -10,8 +10,9 @@ def _handle_table(t: Table):
     :return:
     """
 
-    snow_schema = t.schema or SCHEMA
-    return t.database + "." + snow_schema + "." + t.table_name
+    snow_schema = getattr(t.metadata, "schema", None) or SCHEMA
+    database = getattr(t.metadata, "database", None)
+    return f"{database}.{snow_schema}.{t.name}"
 
 
 def process_params(parameters):

--- a/src/astro/utils/sqlite_merge_func.py
+++ b/src/astro/utils/sqlite_merge_func.py
@@ -1,4 +1,4 @@
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 
 def sqlite_merge_func(
@@ -23,9 +23,9 @@ def sqlite_merge_func(
 
     query = statement.format(
         target_columns=",".join(target_column_names),
-        main_table=target_table.table_name,
+        main_table=target_table.name,
         append_columns=",".join(append_column_names),
-        append_table=merge_table.table_name,
+        append_table=merge_table.name,
         update_statements=",".join(update_statements),
         merge_keys=",".join(list(merge_keys)),
     )

--- a/src/astro/utils/table_handler.py
+++ b/src/astro/utils/table_handler.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pandas
 
 from astro.settings import SCHEMA
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 
 class TableHandler:
@@ -65,13 +65,23 @@ class TableHandler:
 
         if first_table:
             self.conn_id = first_table.conn_id or self.conn_id
-            self.database = first_table.database or self.database
-            self.schema = first_table.schema or self.schema
-            self.warehouse = first_table.warehouse or self.warehouse
-            self.role = first_table.role or self.role
+            self.database = (
+                getattr(first_table.metadata, "database", None) or self.database
+            )
+            self.schema = getattr(first_table.metadata, "schema", None) or self.schema
+            self.warehouse = (
+                getattr(first_table.metadata, "warehouse", None) or self.warehouse
+            )
+            self.role = getattr(first_table.metadata, "role", None) or self.role
 
     def populate_output_table(self):
         self.output_table.conn_id = self.output_table.conn_id or self.conn_id
-        self.output_table.database = self.output_table.database or self.database
-        self.output_table.warehouse = self.output_table.warehouse or self.warehouse
-        self.output_table.schema = self.output_table.schema or SCHEMA
+        self.output_table.metadata.database = (
+            getattr(self.output_table.metadata, "database", None) or self.database
+        )
+        self.output_table.metadata.warehouse = (
+            getattr(self.output_table.metadata, "warehouse", None) or self.warehouse
+        )
+        self.output_table.metadata.schema = (
+            getattr(self.output_table.metadata, "schema", None) or SCHEMA
+        )

--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from airflow import DAG
 
 from astro import sql as aql
-from astro.sql.table import Table
+from astro.sql.tables import Table
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -44,7 +44,7 @@ def create_dag(database_name, table_args, dataset):
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
         chunk_size = int(os.environ["ASTRO_CHUNKSIZE"])
-        table_metadata = Table(table_name=table_name, **table_args)
+        table_metadata = Table(name=table_name, **table_args)
         table_xcom = aql.load_file(  # noqa: F841
             path=dataset_path,
             task_id="load_csv",

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -6,8 +6,9 @@ from airflow.decorators import task, task_group
 from airflow.utils import timezone
 
 from astro import sql as aql
+from astro.databases import create_database, sqlite
 from astro.dataframe import dataframe as adf
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 OUTPUT_TABLE_NAME = test_utils.get_table_name("integration_test_table")
@@ -86,13 +87,14 @@ def run_dataframe_funcs(input_table: Table):
 
 @aql.run_raw_sql
 def add_constraint(table: Table):
-    if table.conn_type == "sqlite":
+    db = create_database(table.conn_id)
+    if isinstance(db, sqlite.SqliteDatabase):
         return "CREATE UNIQUE INDEX unique_index ON {{table}}(list,sell)"
     return "ALTER TABLE {{table}} ADD CONSTRAINT airflow UNIQUE (list,sell)"
 
 
 @task_group
-def run_append(output_specs: TempTable):
+def run_append(output_specs: Table):
     load_main = aql.load_file(
         path=str(CWD) + "/data/homes_main.csv",
         output_table=output_specs,
@@ -110,7 +112,7 @@ def run_append(output_specs: TempTable):
 
 
 @task_group
-def run_merge(output_specs: TempTable, merge_keys):
+def run_merge(output_specs: Table, merge_keys):
     main_table = aql.load_file(
         path=str(CWD) + "/data/homes_merge_1.csv",
         output_table=output_specs,

--- a/tests/miscellaneous/test_table_handler.py
+++ b/tests/miscellaneous/test_table_handler.py
@@ -1,4 +1,4 @@
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from astro.utils.table_handler import TableHandler
 
 
@@ -15,17 +15,21 @@ def test__set_variables_from_first_table_with_same_db_tables_in_op_args():
     handler.op_args = (
         Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
         Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
     )
     handler._set_variables_from_first_table()
@@ -49,17 +53,21 @@ def test__set_variables_from_first_table_with_different_db_tables_in_op_args():
     handler.op_args = (
         Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
         Table(
             conn_id="conn_2",
-            database="database_2",
-            schema="scheme_2",
-            warehouse="warehouse_2",
-            role="role_2",
+            metadata=Metadata(
+                database="database_2",
+                schema="scheme_2",
+                warehouse="warehouse_2",
+                role="role_2",
+            ),
         ),
     )
 
@@ -75,17 +83,21 @@ def test__set_variables_from_first_table_with_same_db_tables_in_python_callable(
     """Test _set_variables_from_first_table() when the tables passed are with same tables in python_callable"""
     table_1 = Table(
         conn_id="conn_1",
-        database="database_1",
-        schema="scheme_1",
-        warehouse="warehouse_1",
-        role="role_1",
+        metadata=Metadata(
+            database="database_1",
+            schema="scheme_1",
+            warehouse="warehouse_1",
+            role="role_1",
+        ),
     )
     table_2 = Table(
         conn_id="conn_1",
-        database="database_1",
-        schema="scheme_1",
-        warehouse="warehouse_1",
-        role="role_1",
+        metadata=Metadata(
+            database="database_1",
+            schema="scheme_1",
+            warehouse="warehouse_1",
+            role="role_1",
+        ),
     )
 
     def dummy_function(param_1: Table, param_2: Table):  # skipcq: PTC-W0049, PY-D0003
@@ -112,17 +124,21 @@ def test__set_variables_from_first_table_with_different_db_tables_in_python_call
     """Test _set_variables_from_first_table() when the tables passed are with same tables in python_callable"""
     table_1 = Table(
         conn_id="conn_1",
-        database="database_1",
-        schema="scheme_1",
-        warehouse="warehouse_1",
-        role="role_1",
+        metadata=Metadata(
+            database="database_1",
+            schema="scheme_1",
+            warehouse="warehouse_1",
+            role="role_1",
+        ),
     )
     table_2 = Table(
         conn_id="conn_2",
-        database="database_2",
-        schema="scheme_2",
-        warehouse="warehouse_2",
-        role="role_2",
+        metadata=Metadata(
+            database="database_2",
+            schema="scheme_2",
+            warehouse="warehouse_2",
+            role="role_2",
+        ),
     )
 
     def dummy_function(param_1: Table, param_2: Table):  # skipcq: PTC-W0049, PY-D0003
@@ -158,17 +174,21 @@ def test__set_variables_from_first_table_with_same_db_tables_in_parameters():
     handler.parameters = {
         "param_1": Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
         "param_3": Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
     }
 
@@ -194,17 +214,21 @@ def test__set_variables_from_first_table_with_different_db_tables_in_parameters(
     handler.parameters = {
         "param_1": Table(
             conn_id="conn_1",
-            database="database_1",
-            schema="scheme_1",
-            warehouse="warehouse_1",
-            role="role_1",
+            metadata=Metadata(
+                database="database_1",
+                schema="scheme_1",
+                warehouse="warehouse_1",
+                role="role_1",
+            ),
         ),
         "param_3": Table(
             conn_id="conn_2",
-            database="database_2",
-            schema="scheme_2",
-            warehouse="warehouse_2",
-            role="role_2",
+            metadata=Metadata(
+                database="database_2",
+                schema="scheme_2",
+                warehouse="warehouse_2",
+                role="role_2",
+            ),
         ),
     }
 

--- a/tests/operators/test_agnostic_aggregate_check.py
+++ b/tests/operators/test_agnostic_aggregate_check.py
@@ -9,7 +9,7 @@ from airflow.utils import timezone
 import astro.sql as aql
 from astro.constants import SUPPORTED_DATABASES, Database
 from astro.settings import SCHEMA
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from tests.operators.utils import get_table_name, run_dag
 
 log = logging.getLogger(__name__)
@@ -20,22 +20,26 @@ CWD = pathlib.Path(__file__).parent
 @pytest.fixture(scope="module")
 def table(request):
     aggregate_table = Table(
-        "aggregate_check_test",
-        database="pagila",
+        name="aggregate_check_test",
         conn_id="postgres_conn",
-        schema="airflow_test_dag",
+        metadata=Metadata(
+            database="pagila",
+            schema="airflow_test_dag",
+        ),
     )
     aggregate_table_bigquery = Table(
-        "aggregate_check_test",
+        name="aggregate_check_test",
         conn_id="bigquery",
-        schema=SCHEMA,
+        metadata=Metadata(schema=SCHEMA),
     )
-    aggregate_table_sqlite = Table("aggregate_check_test", conn_id="sqlite_conn")
+    aggregate_table_sqlite = Table(name="aggregate_check_test", conn_id="sqlite_conn")
     aggregate_table_snowflake = Table(
-        table_name=get_table_name("aggregate_check_test"),
-        database=os.getenv("SNOWFLAKE_DATABASE"),  # type: ignore
-        schema=os.getenv("SNOWFLAKE_SCHEMA"),  # type: ignore
-        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),  # type: ignore
+        name=get_table_name("aggregate_check_test"),
+        metadata=Metadata(
+            database=os.getenv("SNOWFLAKE_DATABASE"),  # type: ignore
+            schema=os.getenv("SNOWFLAKE_SCHEMA"),  # type: ignore
+            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),  # type: ignore
+        ),
         conn_id="snowflake_conn",
     )
     path = str(CWD) + "/../data/homes_merge_1.csv"

--- a/tests/operators/test_agnostic_append.py
+++ b/tests/operators/test_agnostic_append.py
@@ -6,7 +6,7 @@ from airflow.exceptions import BackfillUnfinished
 
 from astro import sql as aql
 from astro.dataframe import dataframe as adf
-from astro.sql.table import TempTable
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 CWD = pathlib.Path(__file__).parent
@@ -95,8 +95,8 @@ def test_append(sql_server, sample_dag, test_table, append_params):
     indirect=True,
 )
 def test_append_on_tables_on_different_db(sample_dag, sql_server):
-    test_table_1 = TempTable(conn_id="postgres_conn")
-    test_table_2 = TempTable(conn_id="sqlite_conn")
+    test_table_1 = Table(conn_id="postgres_conn")
+    test_table_2 = Table(conn_id="sqlite_conn")
     with pytest.raises(BackfillUnfinished):
         with sample_dag:
             load_main = aql.load_file(

--- a/tests/operators/test_agnostic_boolean_check.py
+++ b/tests/operators/test_agnostic_boolean_check.py
@@ -17,7 +17,7 @@ import astro.sql as aql
 from astro.constants import SUPPORTED_DATABASES
 from astro.settings import SCHEMA
 from astro.sql.operators.agnostic_boolean_check import Check
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from tests.operators.utils import get_table_name, run_dag
 
 log = logging.getLogger(__name__)
@@ -49,24 +49,28 @@ def drop_table_snowflake(
 @pytest.fixture(scope="module")
 def table(request):
     boolean_check_table = Table(
-        get_table_name("boolean_check_test"),
-        database="pagila",
+        name=get_table_name("boolean_check_test"),
+        metadata=Metadata(
+            database="pagila",
+            schema="airflow_test_dag",
+        ),
         conn_id="postgres_conn",
-        schema="airflow_test_dag",
     )
     boolean_check_table_bigquery = Table(
-        get_table_name("boolean_check_test"),
+        name=get_table_name("boolean_check_test"),
         conn_id="bigquery",
-        schema=SCHEMA,
+        metadata=Metadata(schema=SCHEMA),
     )
     boolean_check_table_sqlite = Table(
-        get_table_name("boolean_check_test"), conn_id="sqlite_conn"
+        name=get_table_name("boolean_check_test"), conn_id="sqlite_conn"
     )
     boolean_check_table_snowflake = Table(
-        table_name=get_table_name("boolean_check_test"),
-        database=os.getenv("SNOWFLAKE_DATABASE"),  # type: ignore
-        schema=os.getenv("SNOWFLAKE_SCHEMA"),  # type: ignore
-        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),  # type: ignore
+        name=get_table_name("boolean_check_test"),
+        metadata=Metadata(
+            database=os.getenv("SNOWFLAKE_DATABASE"),  # type: ignore
+            schema=os.getenv("SNOWFLAKE_SCHEMA"),  # type: ignore
+            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),  # type: ignore
+        ),
         conn_id="snowflake_conn",
     )
     path = str(CWD) + "/../data/homes_append.csv"

--- a/tests/operators/test_agnostic_load_file.py
+++ b/tests/operators/test_agnostic_load_file.py
@@ -22,7 +22,7 @@ from pandas.testing import assert_frame_equal
 
 from astro.constants import Database
 from astro.sql.operators.agnostic_load_file import load_file
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from astro.utils.dependencies import gcs, s3
 from tests.operators import utils as test_utils
 
@@ -155,8 +155,8 @@ def test_unique_task_id_for_same_path(sample_dag):
                 "path": str(CWD) + "/../data/homes.csv",
                 "file_conn_id": "",
                 "output_table": Table(
-                    OUTPUT_TABLE_NAME,
-                    database="pagila",
+                    name=OUTPUT_TABLE_NAME,
+                    metadata=Metadata(database="pagila"),
                     conn_id="postgres_conn",
                 ),
             }
@@ -293,7 +293,7 @@ def test_load_file_using_file_connection_fails_nonexistent_conn(
     task_params = {
         "path": file_uri,
         "file_conn_id": file_conn_id,
-        "output_table": Table(table_name=OUTPUT_TABLE_NAME, **sql_server_params),
+        "output_table": Table(name=OUTPUT_TABLE_NAME, **sql_server_params),
     }
     with pytest.raises(BackfillUnfinished):
         with sample_dag:

--- a/tests/operators/test_agnostic_merge.py
+++ b/tests/operators/test_agnostic_merge.py
@@ -9,7 +9,7 @@ from airflow.utils import timezone
 from astro import sql as aql
 from astro.constants import Database
 from astro.dataframe import dataframe as adf
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Table
 from astro.utils.database import create_database_from_conn_id
 from tests.operators import utils as test_utils
 
@@ -133,7 +133,7 @@ def validate_results(df: pd.DataFrame, mode, sql_type):
 
 
 @task_group
-def run_merge(output_specs: TempTable, merge_parameters, mode, sql_type):
+def run_merge(output_specs: Table, merge_parameters, mode, sql_type):
     main_table = aql.load_file(
         path=str(CWD) + "/../data/homes_merge_1.csv",
         output_table=output_specs,

--- a/tests/operators/test_dataframe.py
+++ b/tests/operators/test_dataframe.py
@@ -10,7 +10,7 @@ import astro.sql as aql
 from astro import dataframe as df
 from astro.constants import SUPPORTED_DATABASES, Database
 from astro.settings import SCHEMA
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 # Import Operator

--- a/tests/operators/test_snowflake_merge_func.py
+++ b/tests/operators/test_snowflake_merge_func.py
@@ -13,7 +13,7 @@ import unittest
 from airflow.utils import timezone
 
 # Import Operator
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from astro.utils.snowflake_merge_func import (
     is_valid_snow_identifier,
     snowflake_merge_func,
@@ -47,18 +47,22 @@ class TestSnowflakeMerge(unittest.TestCase):
     def setUp(self):
         self.main_table_name = test_utils.get_table_name("merge_test_1")
         self.main_table = Table(
-            table_name=self.main_table_name,
-            database=os.getenv("SNOWFLAKE_DATABASE"),
-            schema=os.getenv("SNOWFLAKE_SCHEMA"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            name=self.main_table_name,
+            metadata=Metadata(
+                database=os.getenv("SNOWFLAKE_DATABASE"),
+                schema=os.getenv("SNOWFLAKE_SCHEMA"),
+                warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            ),
             conn_id="snowflake_conn",
         )
         self.merge_table_name = test_utils.get_table_name("merge_test_2")
         self.merge_table = Table(
-            table_name=self.merge_table_name,
-            database=os.getenv("SNOWFLAKE_DATABASE"),
-            schema=os.getenv("SNOWFLAKE_SCHEMA"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            name=self.merge_table_name,
+            metadata=Metadata(
+                database=os.getenv("SNOWFLAKE_DATABASE"),
+                schema=os.getenv("SNOWFLAKE_SCHEMA"),
+                warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            ),
             conn_id="snowflake_conn",
         )
         super().setUp()

--- a/tests/operators/test_sqlite_append.py
+++ b/tests/operators/test_sqlite_append.py
@@ -26,7 +26,7 @@ from airflow.utils.state import State
 
 # Import Operator
 import astro.sql as aql
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 # from tests.operators import utils as test_utils
@@ -80,11 +80,11 @@ class TestSQLiteAppend(unittest.TestCase):
         self.MAIN_TABLE_NAME = "test_main"
         self.APPEND_TABLE_NAME = "test_append"
         self.main_table = Table(
-            table_name=self.MAIN_TABLE_NAME,
+            name=self.MAIN_TABLE_NAME,
             conn_id="sqlite_conn",
         )
         self.append_table = Table(
-            table_name=self.APPEND_TABLE_NAME,
+            name=self.APPEND_TABLE_NAME,
             conn_id="sqlite_conn",
         )
 

--- a/tests/operators/transform/test_postgres_transform.py
+++ b/tests/operators/transform/test_postgres_transform.py
@@ -9,7 +9,7 @@ from airflow.utils.session import create_session
 
 import astro.sql as aql
 from astro import dataframe as adf
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
@@ -50,7 +50,9 @@ def test_postgres_to_dataframe_partial_output(output_table, dag):
     with dag:
         pg_output = sample_pg(
             input_table=Table(
-                table_name="actor", conn_id="postgres_conn", database="pagila"
+                name="actor",
+                conn_id="postgres_conn",
+                metadata=Metadata(database="pagila"),
             ),
             output_table=output_table,
         )
@@ -74,7 +76,9 @@ def test_with_invalid_dag_name(sample_dag):
     with sample_dag:
         pg_table = pg_query(
             input_table=Table(
-                table_name="actor", conn_id="postgres_conn", database="pagila"
+                name="actor",
+                conn_id="postgres_conn",
+                metadata=Metadata(database="pagila"),
             )
         )
         validate(pg_table)
@@ -114,7 +118,9 @@ def test_postgres(sample_dag, pg_query_result):
     with sample_dag:
         pg_table = pg_query(
             input_table=Table(
-                table_name="actor", conn_id="postgres_conn", database="pagila"
+                name="actor",
+                conn_id="postgres_conn",
+                metadata=Metadata(database="pagila"),
             )
         )
         validate(pg_table)
@@ -142,8 +148,12 @@ def test_postgres_join(sample_dag, test_table, sql_server):
 
     with sample_dag:
         ret = sample_pg(
-            actor=Table(table_name="actor", conn_id="postgres_conn", database="pagila"),
-            film_actor_join=Table(table_name="film_actor"),
+            actor=Table(
+                name="actor",
+                conn_id="postgres_conn",
+                metadata=Metadata(database="pagila"),
+            ),
+            film_actor_join=Table(name="film_actor"),
             unsafe_parameter="G%%",
             output_table=test_table,
         )

--- a/tests/operators/transform/test_snowflake_transform.py
+++ b/tests/operators/transform/test_snowflake_transform.py
@@ -21,7 +21,7 @@ from airflow.utils import timezone
 # Import Operator
 from astro import sql as aql
 from astro.dataframe import dataframe as adf
-from astro.sql.table import Table, TempTable
+from astro.sql.tables import Metadata, Table
 from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
@@ -55,12 +55,14 @@ def snowflake_table(table_name, role):
         table_name=table_name,
     )
     return Table(
-        table_name,
+        name=table_name,
         conn_id="snowflake_conn",
-        schema=os.getenv("SNOWFLAKE_SCHEMA"),
-        database=os.getenv("SNOWFLAKE_DATABASE"),
-        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-        role=role,
+        metadata=Metadata(
+            schema=os.getenv("SNOWFLAKE_SCHEMA"),
+            database=os.getenv("SNOWFLAKE_DATABASE"),
+            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+            role=role,
+        ),
     )
 
 
@@ -81,11 +83,13 @@ def run_role_query(dag, table, role):
 
         f = sample_snow(
             input_table=loaded_table,
-            output_table=TempTable(
+            output_table=Table(
                 conn_id="snowflake_conn",
-                database=os.getenv("SNOWFLAKE_DATABASE"),
-                warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-                role=role,
+                metadata=Metadata(
+                    database=os.getenv("SNOWFLAKE_DATABASE"),
+                    warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                    role=role,
+                ),
             ),
         )
         x = sample_snow(

--- a/tests/operators/transform/test_transform.py
+++ b/tests/operators/transform/test_transform.py
@@ -6,7 +6,7 @@ from airflow.decorators import task
 
 from astro import sql as aql
 from astro.dataframe import dataframe as adf
-from astro.sql.table import Table
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 cwd = pathlib.Path(__file__).parent

--- a/tests/parsers/test_sql_directory_parser.py
+++ b/tests/parsers/test_sql_directory_parser.py
@@ -14,7 +14,7 @@ from airflow.utils.session import create_session
 
 import astro.sql as aql
 from astro.dataframe import dataframe as adf
-from astro.sql.table import Table
+from astro.sql.tables import Metadata, Table
 from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
@@ -120,11 +120,13 @@ class TestSQLParsing(unittest.TestCase):
             input_table = aql.load_file(
                 path=str(cwd) + "/../data/homes.csv",
                 output_table=Table(
-                    test_utils.get_table_name("snowflake_render_test"),
+                    name=test_utils.get_table_name("snowflake_render_test"),
                     conn_id="snowflake_conn",
-                    schema=os.getenv("SNOWFLAKE_SCHEMA"),
-                    database=os.getenv("SNOWFLAKE_DATABASE"),
-                    warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                    metadata=Metadata(
+                        schema=os.getenv("SNOWFLAKE_SCHEMA"),
+                        database=os.getenv("SNOWFLAKE_DATABASE"),
+                        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
+                    ),
                 ),
             )
             models = aql.render(


### PR DESCRIPTION
Replaced all instances of astro.sql.table with astro.sql.tables (the new table). 

This is required for us to work on operator refactoring because we have test cases where we use multiple operators, and these test cases will fail if we refactor one operator involved to use New Table and other operators are still using the old Table.