### PR TITLE
Refactor truncate operator

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -206,7 +206,6 @@ def database_table_fixture(request):
     The table will only be created during setup if request.param contains the `filepath` parameter.
     """
     params = request.param
-    table = params.get("table", NewTable())
     file = params.get("file", None)
 
     database_name = params["database"]
@@ -219,6 +218,9 @@ def database_table_fixture(request):
     conn_id = database_name_to_conn_id[database_name]
     database = create_database(conn_id)
 
+    table = params.get(
+        "table", NewTable(conn_id=conn_id, metadata=database.default_metadata)
+    )
     database.drop_table(table)
     if file:
         database.load_file_to_table(file, table)

--- a/example_dags/example_snowflake_partial_table_with_append.py
+++ b/example_dags/example_snowflake_partial_table_with_append.py
@@ -7,6 +7,7 @@ from airflow.decorators import dag
 from astro import dataframe
 from astro.sql import append, load_file, run_raw_sql, transform, truncate
 from astro.sql.table import Table
+from astro.sql.tables import Table as NewTable
 
 """
 Example ETL DAG highlighting Astro functionality
@@ -127,13 +128,7 @@ def example_snowflake_partial_table_with_append():
     # Why? Between 2022-03-25 and 2022-04-11 it accumulated 301G (89 million rows) because
     # this example DAG used to append rows without deleting them
     truncate_results = truncate(
-        table=Table(
-            table_name="homes_reporting",
-            conn_id=SNOWFLAKE_CONN_ID,
-            database=os.getenv("SNOWFLAKE_DATABASE"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-            schema=os.getenv("SNOWFLAKE_SCHEMA"),
-        )
+        table=NewTable(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID)
     )
     truncate_results.set_upstream(record_results)
 

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -56,5 +56,9 @@ CONN_TYPE_TO_DATABASE = {
 }
 
 LoadExistStrategy = Literal["replace", "append"]
+
+
 ExportExistsStrategy = Literal["replace", "exception"]
-AppendConflictStrategy = Literal["ignore", "update", "exception"]
+
+# TODO: check how snowflake names these
+AppendConflictStrategy = Literal["append", "replace", "exception"]

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -61,10 +61,13 @@ class BaseDatabase(ABC):
         :param sql_statement: Contains SQL query to be run against database
         :param parameters: Optional parameters to be used to render the query
         """
-        if parameters:
-            result = self.hook.run(sql_statement, parameters)
+        if parameters is None:
+            parameters = {}
+
+        if isinstance(sql_statement, str):
+            result = self.connection.execute(sqlalchemy.text(sql_statement), parameters)
         else:
-            result = self.hook.run(sql_statement)
+            result = self.connection.execute(sql_statement, parameters)
         return result
 
     def table_exists(self, table: Table) -> bool:
@@ -90,7 +93,7 @@ class BaseDatabase(ABC):
         # Initially this method belonged to the Table class.
         # However, in order to have an agnostic table class implementation,
         # we are keeping all methods which vary depending on the database within the Database class.
-        if table.metadata is not None and table.metadata.schema is not None:
+        if table.metadata and table.metadata.schema:
             qualified_name = f"{table.metadata.schema}.{table.name}"
         else:
             qualified_name = table.name

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -90,8 +90,10 @@ class BaseDatabase(ABC):
         # Initially this method belonged to the Table class.
         # However, in order to have an agnostic table class implementation,
         # we are keeping all methods which vary depending on the database within the Database class.
-        schema = table.metadata.schema if table.metadata else None
-        qualified_name: str = f"{schema}.{table.name}" if schema else table.name
+        if table.metadata is not None and table.metadata.schema is not None:
+            qualified_name = f"{table.metadata.schema}.{table.name}"
+        else:
+            qualified_name = table.name
         return qualified_name
 
     @property
@@ -151,12 +153,12 @@ class BaseDatabase(ABC):
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         """
-        Upload the content of the source file to the target database.
-        If the table instance does not contain columns, this method automatically identify them using Pandas.
+        Load the content of the source file to the target database table.
+        If the table already exists, append or replace the content, depending on the value of `if_exists`.
 
-        :param source_file: Path to original file (e.g. a "/tmp/sample_data.csv")
-        :param target_table: Details of the target table
-        :param if_exists: Strategy to be applied in case the target table exists
+        :param source_file: Local or remote filepath (e.g. a File("/tmp/sample_data.csv"))
+        :param target_table: Table in which the file will be loaded
+        :param if_exists: Strategy to be used in case the target table already exists
         :param chunk_size: Specify the number of rows in each batch to be written at a time.
         """
         dataframe = source_file.export_to_dataframe()

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -1,5 +1,4 @@
 """Google BigQuery table implementation."""
-
 import pandas as pd
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from sqlalchemy import create_engine

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -33,18 +33,6 @@ class BigqueryDatabase(BaseDatabase):
         uri = self.hook.get_uri()
         return create_engine(uri)
 
-    def get_table_qualified_name(self, table: Table) -> str:
-        """
-        Return table qualified name for BigQuery.
-
-        :param table: The table we want to retrieve the qualified name for.
-        """
-        if table.metadata is not None and table.metadata.schema is not None:
-            qualified_name = f"{table.metadata.schema}.{table.name}"
-        else:
-            qualified_name = table.name
-        return qualified_name
-
     @property
     def default_metadata(self) -> Metadata:
         return Metadata(schema=settings.SCHEMA, database=self.hook.project_id)

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -2,7 +2,7 @@
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 from astro.databases.base import BaseDatabase
-from astro.sql.tables import Metadata, Table
+from astro.sql.tables import Metadata
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
 
@@ -20,18 +20,6 @@ class PostgresDatabase(BaseDatabase):
     def hook(self):
         """Retrieve Airflow hook to interface with the Postgres database."""
         return PostgresHook(postgres_conn_id=self.conn_id)
-
-    def get_table_qualified_name(self, table: Table):
-        """
-        Return table qualified name for Postgres.
-
-        :param table: The table we want to retrieve the qualified name for.
-        """
-        if table.metadata is not None and table.metadata.schema is not None:
-            qualified_name = f"{table.metadata.schema}.{table.name}"
-        else:
-            qualified_name = table.name
-        return qualified_name
 
     @property
     def default_metadata(self) -> Metadata:

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -1,7 +1,8 @@
+"""Postgres database implementation."""
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 from astro.databases.base import BaseDatabase
-from astro.sql.tables import Table
+from astro.sql.tables import Metadata, Table
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
 
@@ -20,11 +21,19 @@ class PostgresDatabase(BaseDatabase):
         """Retrieve Airflow hook to interface with the Postgres database."""
         return PostgresHook(postgres_conn_id=self.conn_id)
 
-    def get_table_qualified_name(self, table: Table) -> str:
+    def get_table_qualified_name(self, table: Table):
         """
-        Return table qualified name. This is Database-specific.
-        For instance, in Sqlite this is the table name. In Snowflake, however, it is the database, schema and table
+        Return table qualified name for Postgres.
 
         :param table: The table we want to retrieve the qualified name for.
         """
-        return str(table.name)
+        if table.metadata is not None and table.metadata.schema is not None:
+            qualified_name = f"{table.metadata.schema}.{table.name}"
+        else:
+            qualified_name = table.name
+        return qualified_name
+
+    @property
+    def default_metadata(self) -> Metadata:
+        schema = self.hook.schema
+        return Metadata(schema=schema)

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -1,10 +1,11 @@
+"""Snowflake database implementation."""
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from pandas.io.sql import SQLDatabase
 
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy
 from astro.databases.base import BaseDatabase
-from astro.sql.tables import Table
+from astro.sql.tables import Metadata, Table
 from astro.utils.dependencies import pandas_tools
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name
@@ -23,6 +24,31 @@ class SnowflakeDatabase(BaseDatabase):
     def hook(self):
         """Retrieve Airflow hook to interface with the snowflake database."""
         return SnowflakeHook(snowflake_conn_id=self.conn_id)
+
+    def get_table_qualified_name(self, table: Table):
+        """
+        Return table qualified name for Snowflake.
+
+        :param table: The table we want to retrieve the qualified name for.
+        """
+        if table.metadata is not None and table.metadata.schema is not None:
+            qualified_name = f"{table.metadata.schema}.{table.name}"
+        else:
+            qualified_name = table.name
+        return qualified_name
+
+    @property
+    def default_metadata(self) -> Metadata:
+        connection = self.hook.get_conn()
+        return Metadata(
+            host=connection.account,
+            schema=connection.schema,
+            warehouse=connection.warehouse,
+            database=connection.database,
+            account=connection.account,
+            role=connection.role,
+            region=connection.region,
+        )
 
     def load_pandas_dataframe_to_table(
         self,

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -25,18 +25,6 @@ class SnowflakeDatabase(BaseDatabase):
         """Retrieve Airflow hook to interface with the snowflake database."""
         return SnowflakeHook(snowflake_conn_id=self.conn_id)
 
-    def get_table_qualified_name(self, table: Table):
-        """
-        Return table qualified name for Snowflake.
-
-        :param table: The table we want to retrieve the qualified name for.
-        """
-        if table.metadata is not None and table.metadata.schema is not None:
-            qualified_name = f"{table.metadata.schema}.{table.name}"
-        else:
-            qualified_name = table.name
-        return qualified_name
-
     @property
     def default_metadata(self) -> Metadata:
         connection = self.hook.get_conn()

--- a/src/astro/databases/sqlite.py
+++ b/src/astro/databases/sqlite.py
@@ -1,9 +1,6 @@
-from typing import Optional, Union
-
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
-from sqlalchemy.engine.result import ResultProxy
 
 from astro.databases.base import BaseDatabase
 from astro.sql.tables import Metadata, Table
@@ -32,20 +29,6 @@ class SqliteDatabase(BaseDatabase):
         if "////" not in uri:
             uri = uri.replace("///", "////")
         return create_engine(uri)
-
-    def run_sql(
-        self, sql_statement: Union[text, str], parameters: Optional[dict] = None
-    ) -> ResultProxy:
-        """
-        Run given SQL statement in the database using the Sqlalchemy engine.
-
-        :param sql_statement: SQL statement to be run on the engine
-        :param parameters: (optional) Parameters to be passed to the SQL statement
-        :return: Result of running the statement.
-        """
-        if parameters is None:
-            parameters = {}
-        return self.connection.execute(sql_statement, parameters)
 
     @property
     def default_metadata(self) -> Metadata:

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -16,7 +16,8 @@ from astro.sql.operators.sql_decorator import (  # noqa: F401
     transform_decorator,
 )
 from astro.sql.parsers.sql_directory_parser import render  # noqa: F401
-from astro.sql.table import Table
+from astro.sql.table import Table as OldTable
+from astro.sql.tables import Table
 
 
 def transform(
@@ -67,8 +68,8 @@ def run_raw_sql(
 
 
 def append(
-    append_table: Table,
-    main_table: Table,
+    append_table: OldTable,
+    main_table: OldTable,
     columns: Optional[List[str]] = None,
     casted_columns: Optional[dict] = None,
     **kwargs,
@@ -87,8 +88,8 @@ def append(
 
 
 def merge(
-    target_table: Table,
-    merge_table: Table,
+    target_table: OldTable,
+    merge_table: OldTable,
     merge_keys: Union[List, dict],
     target_columns: List[str],
     merge_columns: List[str],
@@ -127,13 +128,10 @@ def merge(
 def truncate(
     table: Table,
     **kwargs,
-):
+) -> SqlTruncateOperator:
     """`
-    :param table: The table that we will truncate
-    :param database:
-    :param schema: Snowflake, specific. Specify Snowflake schema
+    :param table: Table to be truncated
     :param kwargs:
-    :return:
     """
 
-    return SqlTruncateOperator(table=table)
+    return SqlTruncateOperator(table=table, **kwargs)

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -6,7 +6,6 @@ from astro.sql.operators.agnostic_load_file import load_file  # noqa: F401
 from astro.sql.operators.agnostic_save_file import save_file  # noqa: F401
 from astro.sql.operators.agnostic_sql_append import SqlAppendOperator
 from astro.sql.operators.agnostic_sql_merge import SqlMergeOperator
-from astro.sql.operators.agnostic_sql_truncate import SqlTruncateOperator
 from astro.sql.operators.agnostic_stats_check import (  # noqa: F401
     OutlierCheck,
     stats_check,
@@ -15,6 +14,7 @@ from astro.sql.operators.sql_decorator import (  # noqa: F401
     SqlDecoratedOperator,
     transform_decorator,
 )
+from astro.sql.operators.truncate import TruncateOperator
 from astro.sql.parsers.sql_directory_parser import render  # noqa: F401
 from astro.sql.table import Table as OldTable
 from astro.sql.tables import Table
@@ -128,10 +128,10 @@ def merge(
 def truncate(
     table: Table,
     **kwargs,
-) -> SqlTruncateOperator:
+) -> TruncateOperator:
     """`
     :param table: Table to be truncated
     :param kwargs:
     """
 
-    return SqlTruncateOperator(table=table, **kwargs)
+    return TruncateOperator(table=table, **kwargs)

--- a/src/astro/sql/operators/agnostic_sql_truncate.py
+++ b/src/astro/sql/operators/agnostic_sql_truncate.py
@@ -23,6 +23,10 @@ class SqlTruncateOperator(BaseOperator):
 
     def execute(self, context: Dict) -> None:  # skipcq: PYL-W0613
         database = create_database(self.table.conn_id)
-        if not self.table.metadata and database.default_metadata:
+        if (
+            self.table.metadata
+            and self.table.metadata.is_empty()
+            and database.default_metadata
+        ):
             self.table.metadata = database.default_metadata
         database.drop_table(self.table)

--- a/src/astro/sql/operators/truncate.py
+++ b/src/astro/sql/operators/truncate.py
@@ -7,7 +7,7 @@ from astro.databases import create_database
 from astro.sql.tables import Table
 
 
-class SqlTruncateOperator(BaseOperator):
+class TruncateOperator(BaseOperator):
     def __init__(
         self,
         table: Table,

--- a/src/astro/sql/operators/truncate.py
+++ b/src/astro/sql/operators/truncate.py
@@ -8,6 +8,8 @@ from astro.sql.tables import Table
 
 
 class TruncateOperator(BaseOperator):
+    """Airflow Operator for truncating SQL tables."""
+
     def __init__(
         self,
         table: Table,
@@ -22,6 +24,7 @@ class TruncateOperator(BaseOperator):
         )
 
     def execute(self, context: Dict) -> None:  # skipcq: PYL-W0613
+        """Method run when the Airflow runner calls the operator."""
         database = create_database(self.table.conn_id)
         if (
             self.table.metadata

--- a/src/astro/sql/tables.py
+++ b/src/astro/sql/tables.py
@@ -15,10 +15,15 @@ class Metadata:
     be database-specific.
     """
 
+    # e.g.: Postgres, Snowflake:
     schema: Union[str, None] = None
+    # e.g.: Snowflake:
+    account: Union[str, None] = None
     database: Union[str, None] = None
-    warehouse: Union[str, None] = None
+    host: Union[str, None] = None
+    region: Union[str, None] = None
     role: Union[str, None] = None
+    warehouse: Union[str, None] = None
 
 
 @dataclass
@@ -46,6 +51,7 @@ class Table:
 
         if not self.name:
             self.name = self._create_unique_table_name()
+            self.temp = True
 
     @staticmethod
     def _create_unique_table_name() -> str:

--- a/src/astro/sql/tables.py
+++ b/src/astro/sql/tables.py
@@ -1,11 +1,11 @@
 import random
 import string
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import List, Optional, Union
 
 from sqlalchemy import Column, MetaData
 
-MAX_TABLE_NAME_LENGTH = 63
+MAX_TABLE_NAME_LENGTH = 62
 
 
 @dataclass
@@ -24,6 +24,11 @@ class Metadata:
     region: Union[str, None] = None
     role: Union[str, None] = None
     warehouse: Union[str, None] = None
+
+    def is_empty(self):
+        """Check if all the fields are None."""
+        values = [getattr(self, field.name) for field in fields(self)]
+        return values.count(None) == len(values)
 
 
 @dataclass
@@ -53,15 +58,15 @@ class Table:
             self.name = self._create_unique_table_name()
             self.temp = True
 
-    @staticmethod
-    def _create_unique_table_name() -> str:
+    def _create_unique_table_name(self) -> str:
         """
         If a table is instantiated without a name, create a unique table for it.
         This new name should be compatible with all supported databases.
         """
+        schema_length = len((self.metadata and self.metadata.schema) or "") + 1
         unique_id = random.choice(string.ascii_lowercase) + "".join(
             random.choice(string.ascii_lowercase + string.digits)
-            for _ in range(MAX_TABLE_NAME_LENGTH - 1)
+            for _ in range(MAX_TABLE_NAME_LENGTH - schema_length)
         )
         return unique_id
 

--- a/tests/databases/test_base_database.py
+++ b/tests/databases/test_base_database.py
@@ -22,6 +22,9 @@ def test_subclass_missing_not_implemented_methods_raise_exception():
         db.connection
 
     with pytest.raises(NotImplementedError):
+        db.default_metadata
+
+    with pytest.raises(NotImplementedError):
         db.run_sql("SELECT * FROM inexistent_table")
 
 

--- a/tests/databases/test_postgres.py
+++ b/tests/databases/test_postgres.py
@@ -73,7 +73,6 @@ def test_table_exists_raises_exception():
         {
             "database": Database.POSTGRES,
             "table": Table(
-                metadata=Metadata(schema=SCHEMA),
                 columns=[
                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
                     sqlalchemy.Column(
@@ -102,13 +101,13 @@ def test_postgres_create_table_with_columns(database_table_fixture):
     assert len(rows) == 2
     assert rows[0][0:4] == (
         "postgres",
-        f"{table.metadata.schema}",
+        "public",
         f"{table.name}",
         "id",
     )
     assert rows[1][0:4] == (
         "postgres",
-        f"{table.metadata.schema}",
+        "public",
         f"{table.name}",
         "name",
     )
@@ -118,10 +117,7 @@ def test_postgres_create_table_with_columns(database_table_fixture):
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
-        {
-            "database": Database.POSTGRES,
-            "table": Table(metadata=Metadata(schema=SCHEMA)),
-        },
+        {"database": Database.POSTGRES},
     ],
     indirect=True,
     ids=["postgres"],
@@ -146,10 +142,7 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
-        {
-            "database": Database.POSTGRES,
-            "table": Table(metadata=Metadata(schema=SCHEMA)),
-        },
+        {"database": Database.POSTGRES},
     ],
     indirect=True,
     ids=["postgres"],
@@ -177,10 +170,7 @@ def test_load_file_to_table(database_table_fixture):
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
-        {
-            "database": Database.POSTGRES,
-            "table": Table(metadata=Metadata(schema=SCHEMA)),
-        },
+        {"database": Database.POSTGRES},
     ],
     indirect=True,
     ids=["postgres"],
@@ -208,7 +198,6 @@ def test_export_table_to_file_file_already_exists_raises_exception(
         {
             "database": Database.POSTGRES,
             "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
-            "table": Table(metadata=Metadata(schema=SCHEMA, database="postgres")),
         },
     ],
     indirect=True,
@@ -239,7 +228,7 @@ def test_export_table_to_file_overrides_existing_file(database_table_fixture):
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
-    [{"database": Database.POSTGRES, "table": Table(metadata=Metadata(schema=SCHEMA))}],
+    [{"database": Database.POSTGRES}],
     indirect=True,
     ids=["postgres"],
 )
@@ -262,7 +251,6 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     [
         {
             "database": Database.POSTGRES,
-            "table": Table(metadata=Metadata(schema=SCHEMA)),
             "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
         }
     ],
@@ -308,12 +296,11 @@ def test_export_table_to_file_in_the_cloud(
     [
         {
             "database": Database.POSTGRES,
-            "table": Table(metadata=Metadata(schema=SCHEMA)),
             "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
         }
     ],
     indirect=True,
-    ids=["POSTGRES"],
+    ids=["postgres"],
 )
 def test_create_table_from_select_statement(database_table_fixture):
     """Test table creation via select statement"""
@@ -322,7 +309,7 @@ def test_create_table_from_select_statement(database_table_fixture):
     statement = "SELECT * FROM {} WHERE id = 1;".format(
         database.get_table_qualified_name(original_table)
     )
-    target_table = Table(metadata=Metadata(schema=SCHEMA))
+    target_table = Table()
     database.create_table_from_select_statement(statement, target_table)
 
     df = database.hook.get_pandas_df(

--- a/tests/databases/test_sqlite.py
+++ b/tests/databases/test_sqlite.py
@@ -56,6 +56,15 @@ def test_sqlite_run_sql():
 
 
 @pytest.mark.integration
+def test_sqlite_run_sql_with_parameters():
+    """Test running a SQL query using SQLAlchemy templating engine"""
+    statement = "SELECT 1 + :value;"
+    database = SqliteDatabase()
+    response = database.run_sql(statement, parameters={"value": 1})
+    assert response.first()[0] == 2
+
+
+@pytest.mark.integration
 def test_table_exists_raises_exception():
     database = SqliteDatabase()
     assert not database.table_exists(Table(name="inexistent-table"))

--- a/tests/databases/test_sqlite.py
+++ b/tests/databases/test_sqlite.py
@@ -56,6 +56,14 @@ def test_sqlite_run_sql():
 
 
 @pytest.mark.integration
+def test_sqlite_run_sql_with_sqlalchemy_text():
+    statement = sqlalchemy.text("SELECT 1 + 1;")
+    database = SqliteDatabase()
+    response = database.run_sql(statement)
+    assert response.first()[0] == 2
+
+
+@pytest.mark.integration
 def test_sqlite_run_sql_with_parameters():
     """Test running a SQL query using SQLAlchemy templating engine"""
     statement = "SELECT 1 + :value;"

--- a/tests/databases/test_sqlite.py
+++ b/tests/databases/test_sqlite.py
@@ -27,6 +27,7 @@ TEST_TABLE = Table()
 
 @pytest.mark.parametrize("conn_id", SUPPORTED_CONN_IDS)
 def test_create_database(conn_id):
+    """Check that the database is created with the correct class."""
     database = create_database(conn_id)
     assert isinstance(database, SqliteDatabase)
 
@@ -40,6 +41,7 @@ def test_create_database(conn_id):
     ids=SUPPORTED_CONN_IDS,
 )
 def test_sqlite_sqlalchemy_engine(conn_id, expected_uri):
+    """Confirm that the SQLALchemy is created successfully."""
     database = SqliteDatabase(conn_id)
     engine = database.sqlalchemy_engine
     assert isinstance(engine, sqlalchemy.engine.base.Engine)
@@ -49,6 +51,7 @@ def test_sqlite_sqlalchemy_engine(conn_id, expected_uri):
 
 @pytest.mark.integration
 def test_sqlite_run_sql():
+    """Run a SQL statement using plain string."""
     statement = "SELECT 1 + 1;"
     database = SqliteDatabase()
     response = database.run_sql(statement)
@@ -57,6 +60,7 @@ def test_sqlite_run_sql():
 
 @pytest.mark.integration
 def test_sqlite_run_sql_with_sqlalchemy_text():
+    """Run a SQL statement using SQLAlchemy text"""
     statement = sqlalchemy.text("SELECT 1 + 1;")
     database = SqliteDatabase()
     response = database.run_sql(statement)
@@ -74,6 +78,7 @@ def test_sqlite_run_sql_with_parameters():
 
 @pytest.mark.integration
 def test_table_exists_raises_exception():
+    """Raise an exception when checking for a non-existent table"""
     database = SqliteDatabase()
     assert not database.table_exists(Table(name="inexistent-table"))
 
@@ -98,6 +103,7 @@ def test_table_exists_raises_exception():
     ids=["sqlite"],
 )
 def test_sqlite_create_table_with_columns(database_table_fixture):
+    """Create a table using specific columns and types"""
     database, table = database_table_fixture
 
     statement = f"PRAGMA table_info({table.name});"
@@ -122,6 +128,7 @@ def test_sqlite_create_table_with_columns(database_table_fixture):
     ids=["sqlite"],
 )
 def test_load_pandas_dataframe_to_table(database_table_fixture):
+    """Load Pandas Dataframe to a SQL table"""
     database, table = database_table_fixture
 
     pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
@@ -146,6 +153,7 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     ids=["sqlite"],
 )
 def test_load_file_to_table(database_table_fixture):
+    """Load a file to a SQL table"""
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     database.load_file_to_table(File(filepath), target_table)
@@ -173,6 +181,7 @@ def test_load_file_to_table(database_table_fixture):
 def test_export_table_to_file_file_already_exists_raises_exception(
     database_table_fixture,
 ):
+    """Raise exception if trying to export to file that exists"""
     database, source_table = database_table_fixture
     filepath = pathlib.Path(CWD.parent, "data/sample.csv")
     with pytest.raises(FileExistsError) as exception_info:
@@ -195,6 +204,7 @@ def test_export_table_to_file_file_already_exists_raises_exception(
     ids=["sqlite"],
 )
 def test_export_table_to_file_overrides_existing_file(database_table_fixture):
+    """Override file if using the replace option"""
     database, populated_table = database_table_fixture
 
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv").absolute())
@@ -222,6 +232,7 @@ def test_export_table_to_file_overrides_existing_file(database_table_fixture):
 def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     database_table_fixture,
 ):
+    """Export table to a Pandas dataframe"""
     database, non_existent_table = database_table_fixture
 
     with pytest.raises(NonExistentTableException) as exc_info:
@@ -252,6 +263,7 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
 def test_export_table_to_file_in_the_cloud(
     database_table_fixture, remote_files_fixture
 ):
+    """Export a SQL tale to a file in the cloud"""
     object_path = remote_files_fixture[0]
     database, populated_table = database_table_fixture
 
@@ -288,6 +300,7 @@ def test_export_table_to_file_in_the_cloud(
     ids=["sqlite"],
 )
 def test_create_table_from_select_statement(database_table_fixture):
+    """Create a table given a SQL select statement"""
     database, original_table = database_table_fixture
 
     statement = "SELECT * FROM {} WHERE id = 1;".format(

--- a/tests/operators/test_agnostic_truncate.py
+++ b/tests/operators/test_agnostic_truncate.py
@@ -9,6 +9,7 @@ from airflow.utils import timezone
 import astro.sql as aql
 from astro.constants import Database
 from astro.files import File
+from astro.sql.tables import Table
 from tests.operators import utils as test_utils
 
 log = logging.getLogger(__name__)
@@ -41,7 +42,34 @@ DEFAULT_FILEPATH = str(pathlib.Path(CWD.parent, "data/sample.csv").absolute())
     indirect=True,
     ids=["sqlite", "postgres", "bigquery", "snowflake"],
 )
-def test_truncate(database_table_fixture, sample_dag):
+def test_truncate_with_table_metadata(database_table_fixture, sample_dag):
+    """Test truncate operator for all databases."""
+    database, test_table = database_table_fixture
+    assert database.table_exists(test_table)
+
+    with sample_dag:
+        aql.truncate(
+            table=test_table,
+        )
+    test_utils.run_dag(sample_dag)
+
+    assert not database.table_exists(test_table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.POSTGRES,
+            "table": Table(conn_id="postgres_conn"),
+            "file": File(DEFAULT_FILEPATH),
+        }
+    ],
+    indirect=True,
+    ids=["postgres"],
+)
+def test_truncate_without_table_metadata(database_table_fixture, sample_dag):
     """Test truncate operator for all databases."""
     database, test_table = database_table_fixture
     assert database.table_exists(test_table)

--- a/tests/sql/operator/test_truncate.py
+++ b/tests/sql/operator/test_truncate.py
@@ -15,7 +15,7 @@ from tests.operators import utils as test_utils
 log = logging.getLogger(__name__)
 CWD = pathlib.Path(__file__).parent
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-DEFAULT_FILEPATH = str(pathlib.Path(CWD.parent, "data/sample.csv").absolute())
+DEFAULT_FILEPATH = str(pathlib.Path(CWD.parent.parent, "data/sample.csv").absolute())
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Resolve  #342

There are some decisions taken during the development of this ticket that will affect other parts of the project:

1. Retrieve the schema and other metadata from the connection if the table doesn't contain metadata. The only exception is BigQuery - since it seems there is no standard way of defining the schema for this type of connection. In the case of BigQuery, we're retrieving the schema from the environment variable if not defined in the table creation.

2. Use SQLAlchemy to run SQL queries. The initial intent to use Airflow hooks was to simplify the future adoption of AsyncOperators. However, each of the currently supported DBs implements the hooks differently (for BQ, for instance, `run_sql` returns a job ID). Additionally, each hook produces the output in a different format. Since we are focused on the refactoring, for now, and not on AsyncOperators - I decided to stick to the standard and straightforward interface for performing SQL queries. We can revisit this in the future.