### PR TITLE
Fix import of logging library

### DIFF
--- a/src/astro/sql/operators/agnostic_boolean_check.py
+++ b/src/astro/sql/operators/agnostic_boolean_check.py
@@ -1,4 +1,4 @@
-from distutils import log as logger
+import logging
 from typing import Any, Dict, List, Optional
 
 from airflow.hooks.base import BaseHook
@@ -10,6 +10,8 @@ from astro.databases import create_database
 from astro.sql.operators.sql_decorator import SqlDecoratedOperator
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_unique_task_id
+
+log = logging.getLogger(__name__)
 
 
 class Check:
@@ -86,7 +88,7 @@ class AgnosticBooleanCheck(SqlDecoratedOperator):
             }
             self.sql = self.prep_results(failed_checks_index)
             failed_rows = super().execute(context)
-            logger.error("Failed rows %s", failed_rows)
+            log.error("Failed rows %s", failed_rows)
             raise ValueError(
                 "Some of the check(s) have failed %s", ",".join(failed_checks_names)
             )


### PR DESCRIPTION
disutils is deprecated library and logging should be imported from logger anyway

This was reported by deepsource too - https://deepsource.io/gh/astro-projects/astro/run/f56c08a6-52b6-4cca-a619-27d66bf65cf5/python/PYL-W0402